### PR TITLE
docs: list Numen Creative community addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Minecraft 真正的宇宙在模组里：机械动力（Create）的齿轮传动�
 **扩展一个同伴**——同伴自己的大脑仍然做主：
 - **桥（Bridge）** 把一个外部渠道接进同伴：消息进来，同伴自己决定怎么做。基于 `NumenGateway`。→ **[numen-qq-bridge](https://github.com/Dwinovo/numen-qq-bridge)**（QQ），后续还有更多。
 - **技能（Skill）** 教同伴怎么做事——markdown 注入它的上下文。随 Numen 内置，或社区编写。
+- **社区 Addon** 为同伴增加面向特定玩法的工具和技能。→ **[Numen Creative](https://github.com/venti0824/numen-creative)**（非官方社区扩展；Minecraft 1.20.1 Forge、Numen 0.0.7、Java 17）
 
 **把 Numen 暴露出去**——把操控权交给外部大脑：
 - **[numen-mcp](https://github.com/Dwinovo/numen-mcp)** 是一个 Model Context Protocol 服务器：任意外部智能体（比如 Claude）直接驱动同伴。基于 `NumenActuator`。

--- a/README_EN.md
+++ b/README_EN.md
@@ -137,6 +137,7 @@ Every mod you can name, the AI can play. It's a big promise — but every brick 
 **Extend a companion** — its own brain stays in charge:
 - **Bridges** carry an outside channel into a companion: a message arrives, and the companion decides what to do. Built on `NumenGateway`. → **[numen-qq-bridge](https://github.com/Dwinovo/numen-qq-bridge)** (QQ), with more to come.
 - **Skills** teach a companion how to behave — markdown loaded into its context. Bundled with Numen, or community-written.
+- **Community addons** add tools and skills for a particular play style. → **[Numen Creative](https://github.com/venti0824/numen-creative)** (unofficial community addon; Minecraft 1.20.1 Forge, Numen 0.0.7, Java 17)
 
 **Expose Numen** — hand the controls to an outside brain:
 - **[numen-mcp](https://github.com/Dwinovo/numen-mcp)** is a Model Context Protocol server: any external agent (like Claude) drives companions directly. Built on `NumenActuator`.


### PR DESCRIPTION
## Summary
- list Numen Creative in the Chinese and English ecosystem sections
- label it as an unofficial community addon
- state the exact compatibility target: Minecraft 1.20.1 Forge, Numen 0.0.7, Java 17

## Verification
- representative in-game smoke test: https://github.com/venti0824/numen-creative/blob/main/docs/testing/2026-07-20-forge-1.20.1-smoke-test.md
- documentation-only change

Related to #4.