### PR TITLE
feat: add autonomous vanilla fishing tool | 添加钓鱼tool

### DIFF
--- a/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
@@ -22,6 +22,8 @@ import com.dwinovo.numen.core.task.EatCompanionTask;
 import com.dwinovo.numen.core.task.EatItemTaskRecord;
 import com.dwinovo.numen.core.task.EquipCompanionTask;
 import com.dwinovo.numen.core.task.EquipTaskRecord;
+import com.dwinovo.numen.core.task.FishCompanionTask;
+import com.dwinovo.numen.core.task.FishTaskRecord;
 import com.dwinovo.numen.core.task.MeleeAttackCompanionTask;
 import com.dwinovo.numen.core.task.MeleeAttackTaskRecord;
 import com.dwinovo.numen.core.task.RangedAttackCompanionTask;
@@ -114,6 +116,7 @@ public final class NumenCore {
         ToolRegistry.register(new com.dwinovo.numen.core.tools.LocateStructureTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.LocateBiomeTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.CollectItemsTool());
+        ToolRegistry.register(new com.dwinovo.numen.core.tools.FishTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.AutoMineTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.EquipItemTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.BuildTool());
@@ -150,6 +153,7 @@ public final class NumenCore {
         CompanionTaskFactory.register(MeleeAttackTaskRecord.class, (p, r) -> new MeleeAttackCompanionTask(p, r));
         CompanionTaskFactory.register(RangedAttackTaskRecord.class, (p, r) -> new RangedAttackCompanionTask(p, r));
         CompanionTaskFactory.register(CollectItemsTaskRecord.class, (p, r) -> new CollectItemsTaskGoal(p, r));
+        CompanionTaskFactory.register(FishTaskRecord.class, (p, r) -> new FishCompanionTask(p, r));
         CompanionTaskFactory.register(BuildTaskRecord.class, (p, r) -> new BuildCompanionTask(p, r));
         CompanionTaskFactory.register(InteractAtTaskRecord.class, (p, r) -> new InteractAtCompanionTask(p, r));
         CompanionTaskFactory.register(InteractEntityTaskRecord.class, (p, r) -> new InteractEntityCompanionTask(p, r));
@@ -157,4 +161,3 @@ public final class NumenCore {
         CompanionTaskFactory.register(LocateBiomeTaskRecord.class, (p, r) -> new LocateBiomeTaskGoal(p, r));
     }
 }
-

--- a/common/src/main/java/com/dwinovo/numen/core/mixin/FishingHookAccessor.java
+++ b/common/src/main/java/com/dwinovo/numen/core/mixin/FishingHookAccessor.java
@@ -1,0 +1,13 @@
+package com.dwinovo.numen.core.mixin;
+
+import net.minecraft.world.entity.projectile.FishingHook;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/** Read-only access to vanilla's private successful-bite countdown. */
+@Mixin(FishingHook.class)
+public interface FishingHookAccessor {
+
+    @Accessor("nibble")
+    int numen$getNibble();
+}

--- a/common/src/main/java/com/dwinovo/numen/core/task/FishCompanionTask.java
+++ b/common/src/main/java/com/dwinovo/numen/core/task/FishCompanionTask.java
@@ -1,0 +1,698 @@
+package com.dwinovo.numen.core.task;
+
+import com.dwinovo.numen.core.Constants;
+import com.dwinovo.numen.core.mixin.FishingHookAccessor;
+import com.dwinovo.numen.core.pathing.calc.NavGoal;
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.util.BlockHelper;
+import com.dwinovo.numen.core.task.base.AbstractCompanionTask;
+import com.dwinovo.numen.core.task.base.Precondition;
+import com.dwinovo.numen.entity.InputDriver;
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.dwinovo.numen.task.TaskState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.projectile.FishingHook;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Tick-driven vanilla fishing from a nearby water surface. */
+public final class FishCompanionTask extends AbstractCompanionTask<FishTaskRecord> {
+
+    private enum Phase { POSITION, PREPARE, AIM, WAIT, COLLECT, COOLDOWN }
+
+    private record FishingSetup(BlockPos stance, BlockPos water) {}
+
+    private static final int STANCE_SEARCH_RADIUS = 12;
+    private static final int STANCE_SEARCH_Y = 4;
+    private static final int MAX_STANCE_CHECKS = 256;
+    private static final int MAX_POSITION_FAILURES = 3;
+    private static final double NAV_SPEED = 1.0;
+
+    private static final int CAST_SEARCH_RADIUS = 10;
+    private static final int CAST_SEARCH_Y = 4;
+    private static final double MIN_CAST_DISTANCE = 4.0;
+    private static final double IDEAL_CAST_DISTANCE = 6.0;
+    private static final double WATER_SURFACE_OFFSET = 0.85;
+    private static final int AIM_TICKS = 3;
+    private static final int CAST_SETTLE_TIMEOUT = 5 * 20;
+    private static final int CAST_LIFETIME = 60 * 20;
+    private static final int COOLDOWN_TICKS = 10;
+    private static final int MAX_FAILED_CASTS = 5;
+
+    /** Vanilla reels the loot toward the player, but terrain can stop it short. */
+    private static final double LOOT_SEARCH_RADIUS = 18.0;
+    private static final double PICKUP_REACH_SQR = 1.5;
+    private static final int LOOT_DISCOVERY_TICKS = 10;
+    /** Let vanilla's reel impulse bring the catch back before chasing it. */
+    private static final int LOOT_RETURN_GRACE_TICKS = 20;
+    private static final int LOOT_CLOSE_WAIT_TICKS = 20;
+    private static final int LOOT_COLLECTION_TIMEOUT = 20 * 20;
+
+    private static final double FISHING_DRAG = 0.92;
+    private static final double FISHING_GRAVITY = 0.03;
+    private static final int MAX_FLIGHT_TICKS = 80;
+
+    private final Set<BlockPos> rejectedStances = new HashSet<>();
+    private final Set<BlockPos> rejectedTargets = new HashSet<>();
+    /** Item ids that existed before the reel, so nearby clutter is not claimed as this catch. */
+    private final Set<Integer> preReelItems = new HashSet<>();
+    /** Exact ItemEntity instances spawned by the successful vanilla reel. */
+    private final Map<Integer, ItemEntity> caughtLoot = new HashMap<>();
+
+    private Phase phase = Phase.POSITION;
+    private BlockPos stance;
+    private BlockPos target;
+    private int phaseTicks;
+    private int failedCasts;
+    private int positionFailures;
+    private ItemEntity lootTarget;
+    private int lootCloseTicks;
+    private int unreachableLoot;
+
+    public FishCompanionTask(NumenPlayer player, FishTaskRecord record) {
+        super(player, record);
+    }
+
+    @Override
+    protected List<Precondition> preconditions() {
+        return List.of(() -> findRodSlot() >= 0 ? null
+                : new Precondition.Failure("fish needs a fishing rod in inventory",
+                        FailureType.WRONG_TOOL));
+    }
+
+    @Override
+    protected TaskState onTick() {
+        if (player.isDeadOrDying()) return TaskState.CANCELLED;
+
+        InputDriver.halt(player);
+        if (phase == Phase.POSITION) return positionForFishing();
+        if (phase == Phase.COLLECT) return collectCaughtLoot();
+        if (r.caught() >= r.requested) return TaskState.SUCCESS;
+
+        int rodSlot = findRodSlot();
+        if (rodSlot < 0) {
+            discardHook();
+            fail("fishing stopped because there is no fishing rod left", FailureType.WRONG_TOOL);
+            return TaskState.FAILED;
+        }
+        player.holdInHand(rodSlot);
+        if (!player.getMainHandItem().is(Items.FISHING_ROD)) return TaskState.RUNNING;
+
+        return switch (phase) {
+            case POSITION -> throw new IllegalStateException("position phase handled above");
+            case PREPARE -> prepare();
+            case AIM -> aimAndCast();
+            case WAIT -> waitForBite();
+            case COLLECT -> throw new IllegalStateException("collect phase handled above");
+            case COOLDOWN -> coolDown();
+        };
+    }
+
+    private TaskState positionForFishing() {
+        if (stance == null || target == null) {
+            FishingSetup setup = findFishingSetup();
+            if (setup == null) {
+                fail("no safe dry fishing stance with reachable water nearby; move close to a shoreline and try fish again",
+                        FailureType.OUT_OF_REACH);
+                return TaskState.FAILED;
+            }
+            stance = setup.stance();
+            target = setup.water();
+        }
+
+        if (atStance()) {
+            stopNav();
+            phase = Phase.PREPARE;
+            return TaskState.RUNNING;
+        }
+        if (nav == null) {
+            nav = PlayerNav.toGoal(player, () -> NavGoal.exact(stance), NAV_SPEED, this::atStance);
+        }
+        return switch (nav.tick()) {
+            case RUNNING -> TaskState.RUNNING;
+            case ARRIVED -> {
+                stopNav();
+                phase = Phase.PREPARE;
+                yield TaskState.RUNNING;
+            }
+            case FAILED -> {
+                rejectedStances.add(stance);
+                stopNav();
+                stance = null;
+                target = null;
+                if (++positionFailures >= MAX_POSITION_FAILURES) {
+                    fail("nearby dry fishing stances were unreachable; move onto a clear shoreline and try fish again",
+                            FailureType.NO_PATH);
+                    yield TaskState.FAILED;
+                }
+                yield TaskState.RUNNING;
+            }
+        };
+    }
+
+    private FishingSetup findFishingSetup() {
+        BlockPos current = feet();
+        if (isDryStance(current) && !rejectedStances.contains(current)) {
+            BlockPos water = findCastTarget(current, player.getEyePosition());
+            if (water != null) return new FishingSetup(current, water);
+            // Already safely on land but no water is in casting range. Long-distance
+            // water discovery belongs to the model's locate/move step, not this job.
+            return null;
+        }
+
+        List<BlockPos> candidates = new ArrayList<>();
+        BlockPos origin = player.blockPosition();
+        for (int dy = -STANCE_SEARCH_Y; dy <= STANCE_SEARCH_Y; dy++) {
+            for (int dx = -STANCE_SEARCH_RADIUS; dx <= STANCE_SEARCH_RADIUS; dx++) {
+                for (int dz = -STANCE_SEARCH_RADIUS; dz <= STANCE_SEARCH_RADIUS; dz++) {
+                    if (dx * dx + dz * dz > STANCE_SEARCH_RADIUS * STANCE_SEARCH_RADIUS) continue;
+                    BlockPos candidate = origin.offset(dx, dy, dz);
+                    if (!rejectedStances.contains(candidate) && isDryStance(candidate)) {
+                        candidates.add(candidate.immutable());
+                    }
+                }
+            }
+        }
+        candidates.sort(Comparator.comparingDouble(current::distSqr));
+        int checks = Math.min(MAX_STANCE_CHECKS, candidates.size());
+        for (int i = 0; i < checks; i++) {
+            BlockPos candidate = candidates.get(i);
+            Vec3 eye = new Vec3(candidate.getX() + 0.5,
+                    candidate.getY() + player.getEyeHeight(), candidate.getZ() + 0.5);
+            BlockPos water = findCastTarget(candidate, eye);
+            if (water != null) return new FishingSetup(candidate, water);
+        }
+        return null;
+    }
+
+    private TaskState prepare() {
+        if (player.fishing != null) {
+            discardHook();
+            return TaskState.RUNNING;
+        }
+
+        BlockPos current = feet();
+        if (!isDryStance(current)) {
+            resetPositioning();
+            return TaskState.RUNNING;
+        }
+        if (!current.equals(stance)) {
+            stance = current;
+            target = null;
+        }
+        if (target == null || !isCastableSurface(target)
+                || !trajectoryClear(player.getEyePosition(), target)) {
+            target = findCastTarget(stance, player.getEyePosition());
+        }
+        if (target == null && !rejectedTargets.isEmpty()) {
+            // A tiny pond may expose only one valid landing cell. After trying all
+            // distinct candidates, permit another ballistic attempt instead of
+            // converting one unlucky cast into a permanent "no water" verdict.
+            rejectedTargets.clear();
+            target = findCastTarget(stance, player.getEyePosition());
+        }
+        if (target == null) {
+            fail("no unobstructed fishing cast is available from this dry stance; move along the shoreline and try again",
+                    FailureType.OUT_OF_REACH);
+            return TaskState.FAILED;
+        }
+
+        phase = Phase.AIM;
+        phaseTicks = 0;
+        aimAtTarget();
+        return TaskState.RUNNING;
+    }
+
+    private TaskState aimAndCast() {
+        if (!isCastableSurface(target) || !trajectoryClear(player.getEyePosition(), target)) {
+            return failedCast("the selected water surface became obstructed", true);
+        }
+        aimAtTarget();
+        if (++phaseTicks < AIM_TICKS) return TaskState.RUNNING;
+
+        double pitch = castPitchDegrees(player.getEyePosition(), target);
+        player.gameMode.useItem(player, player.level(), player.getMainHandItem(), InteractionHand.MAIN_HAND);
+        r.castOnce();
+        if (player.fishing == null) {
+            return failedCast("the fishing rod did not cast", false);
+        }
+        Constants.LOG.debug("[numen-fish] cast={} target={} pitch={}", r.casts(),
+                target.toShortString(), String.format(java.util.Locale.ROOT, "%.1f", pitch));
+        phase = Phase.WAIT;
+        phaseTicks = 0;
+        return TaskState.RUNNING;
+    }
+
+    private TaskState waitForBite() {
+        FishingHook hook = player.fishing;
+        if (hook == null || hook.isRemoved()) {
+            return failedCast("the fishing hook disappeared before a catch", false);
+        }
+        phaseTicks++;
+
+        Entity hooked = hook.getHookedIn();
+        if (hooked != null) {
+            reelIn();
+            return failedCast("the hook caught an entity instead of landing cleanly", true);
+        }
+
+        int nibble = ((FishingHookAccessor) (Object) hook).numen$getNibble();
+        if (isBiteWindow(nibble)) {
+            beginLootCollection();
+            r.caughtOne();
+            Constants.LOG.debug("[numen-fish] caught={}/{} casts={}",
+                    r.caught(), r.requested, r.casts());
+            return TaskState.RUNNING;
+        }
+
+        boolean inWater = hook.level().getFluidState(hook.blockPosition()).is(FluidTags.WATER);
+        if (!inWater && phaseTicks >= CAST_SETTLE_TIMEOUT) {
+            Constants.LOG.debug("[numen-fish] miss hook={} on_ground={} age={}",
+                    hook.blockPosition().toShortString(), hook.onGround(), phaseTicks);
+            return failedCast("the fishing hook did not settle in water", true);
+        }
+        if (phaseTicks >= CAST_LIFETIME) {
+            return failedCast("no bite arrived before the cast timed out", false);
+        }
+        return TaskState.RUNNING;
+    }
+
+    /**
+     * Finish the semantic catch, not merely the rod interaction: walk to every
+     * ItemEntity created by this reel until vanilla pickup absorbs it. Fishing
+     * loot is launched toward the owner, but a bank, slab or ledge can intercept
+     * it several blocks away (the exact failure seen in ordinary play-testing).
+     */
+    private TaskState collectCaughtLoot() {
+        phaseTicks++;
+        if (phaseTicks <= LOOT_DISCOVERY_TICKS) discoverCaughtLoot();
+
+        if (phaseTicks >= LOOT_COLLECTION_TIMEOUT) {
+            int remaining = (int) caughtLoot.values().stream().filter(e -> !e.isRemoved()).count();
+            fail("reeled in fishing loot but timed out while retrieving " + remaining
+                    + " dropped loot item(s)", FailureType.NO_PATH);
+            return TaskState.FAILED;
+        }
+
+        // A vanilla reel launches its loot toward the owner. Planning against that
+        // still-moving entity makes the body step off the bank to "meet" a catch
+        // that would have arrived by itself. Hold the known-safe stance briefly;
+        // genuine stranded loot is still path-found after this grace period.
+        boolean returningLoot = caughtLoot.values().stream().anyMatch(e -> !e.isRemoved());
+        if (returningLoot && phaseTicks <= LOOT_RETURN_GRACE_TICKS) {
+            return TaskState.RUNNING;
+        }
+
+        if (lootTarget != null) {
+            if (lootTarget.isRemoved()) {
+                caughtLoot.remove(lootTarget.getId());
+                lootTarget = null;
+                lootCloseTicks = 0;
+                stopNav();
+            } else if (player.distanceToSqr(lootTarget) <= PICKUP_REACH_SQR) {
+                // Give vanilla collision pickup a full second. This also produces
+                // a useful failure for a full inventory instead of looping forever.
+                stopNav();
+                if (++lootCloseTicks >= LOOT_CLOSE_WAIT_TICKS) abandonLootTarget();
+                return TaskState.RUNNING;
+            } else {
+                lootCloseTicks = 0;
+                if (nav == null) {
+                    nav = new PlayerNav(player, lootTarget::blockPosition, NAV_SPEED,
+                            () -> lootTarget == null || lootTarget.isRemoved()
+                                    || player.distanceToSqr(lootTarget) <= PICKUP_REACH_SQR);
+                }
+                switch (nav.tick()) {
+                    case RUNNING -> { return TaskState.RUNNING; }
+                    case ARRIVED -> { return TaskState.RUNNING; }
+                    case FAILED -> {
+                        abandonLootTarget();
+                        return TaskState.RUNNING;
+                    }
+                }
+            }
+        }
+
+        caughtLoot.entrySet().removeIf(e -> e.getValue().isRemoved());
+        lootTarget = caughtLoot.values().stream()
+                .filter(e -> !e.isRemoved())
+                .min(Comparator.comparingDouble(player::distanceToSqr))
+                .orElse(null);
+        if (lootTarget != null) {
+            stopNav();
+            return TaskState.RUNNING;
+        }
+
+        // A freshly spawned catch can be absorbed on the same tick or become
+        // query-visible one tick later. Keep the short discovery window before
+        // deciding that there is nothing left to retrieve.
+        if (phaseTicks < LOOT_DISCOVERY_TICKS) return TaskState.RUNNING;
+        if (unreachableLoot > 0) {
+            fail("reeled in fishing loot but could not reach " + unreachableLoot
+                    + " dropped loot item(s)", FailureType.NO_PATH);
+            return TaskState.FAILED;
+        }
+        clearLootTracking();
+        beginCooldown();
+        return TaskState.RUNNING;
+    }
+
+    private void beginLootCollection() {
+        preReelItems.clear();
+        caughtLoot.clear();
+        lootTarget = null;
+        lootCloseTicks = 0;
+        unreachableLoot = 0;
+        for (ItemEntity item : nearbyItems()) preReelItems.add(item.getId());
+
+        reelIn();
+        phase = Phase.COLLECT;
+        phaseTicks = 0;
+        stopNav();
+        discoverCaughtLoot();
+    }
+
+    /** Find only entities introduced by the reel, never unrelated ground clutter. */
+    private void discoverCaughtLoot() {
+        for (ItemEntity item : nearbyItems()) {
+            if (!preReelItems.contains(item.getId())) caughtLoot.putIfAbsent(item.getId(), item);
+        }
+    }
+
+    private List<ItemEntity> nearbyItems() {
+        return player.level().getEntitiesOfClass(ItemEntity.class,
+                player.getBoundingBox().inflate(LOOT_SEARCH_RADIUS), item -> !item.isRemoved());
+    }
+
+    private void abandonLootTarget() {
+        if (lootTarget != null) caughtLoot.remove(lootTarget.getId());
+        unreachableLoot++;
+        lootTarget = null;
+        lootCloseTicks = 0;
+        stopNav();
+    }
+
+    private void clearLootTracking() {
+        preReelItems.clear();
+        caughtLoot.clear();
+        lootTarget = null;
+        lootCloseTicks = 0;
+        unreachableLoot = 0;
+        stopNav();
+    }
+
+    private TaskState coolDown() {
+        if (++phaseTicks < COOLDOWN_TICKS) return TaskState.RUNNING;
+        if (r.caught() >= r.requested) return TaskState.SUCCESS;
+        phase = Phase.PREPARE;
+        phaseTicks = 0;
+        return TaskState.RUNNING;
+    }
+
+    private TaskState failedCast(String reason, boolean rejectTarget) {
+        BlockPos failedTarget = target;
+        discardHook();
+        if (rejectTarget && failedTarget != null) rejectedTargets.add(failedTarget);
+        if (++failedCasts >= MAX_FAILED_CASTS) {
+            fail(reason + " after " + failedCasts
+                    + " attempts; move to a clearer shoreline and try fish again", FailureType.OUT_OF_REACH);
+            return TaskState.FAILED;
+        }
+        phase = Phase.PREPARE;
+        phaseTicks = 0;
+        if (rejectTarget) target = null;
+        return TaskState.RUNNING;
+    }
+
+    private void beginCooldown() {
+        phase = Phase.COOLDOWN;
+        phaseTicks = 0;
+        failedCasts = 0;
+        rejectedTargets.clear();
+    }
+
+    private void resetPositioning() {
+        discardHook();
+        stopNav();
+        clearLootTracking();
+        phase = Phase.POSITION;
+        phaseTicks = 0;
+        stance = null;
+        target = null;
+        rejectedTargets.clear();
+    }
+
+    private void reelIn() {
+        if (player.fishing != null && player.getMainHandItem().is(Items.FISHING_ROD)) {
+            player.gameMode.useItem(player, player.level(), player.getMainHandItem(),
+                    InteractionHand.MAIN_HAND);
+        }
+    }
+
+    private int findRodSlot() {
+        var inventory = player.getInventory();
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack stack = inventory.getItem(i);
+            if (stack.is(Items.FISHING_ROD)) return i;
+        }
+        return -1;
+    }
+
+    private BlockPos findCastTarget(BlockPos fromStance, Vec3 eye) {
+        List<BlockPos> candidates = new ArrayList<>();
+        for (int dy = -CAST_SEARCH_Y; dy <= CAST_SEARCH_Y; dy++) {
+            for (int dx = -CAST_SEARCH_RADIUS; dx <= CAST_SEARCH_RADIUS; dx++) {
+                for (int dz = -CAST_SEARCH_RADIUS; dz <= CAST_SEARCH_RADIUS; dz++) {
+                    double horizontal = Math.sqrt(dx * dx + dz * dz);
+                    if (horizontal < MIN_CAST_DISTANCE || horizontal > CAST_SEARCH_RADIUS) continue;
+                    BlockPos candidate = fromStance.offset(dx, dy, dz);
+                    if (!rejectedTargets.contains(candidate) && isCastableSurface(candidate)) {
+                        candidates.add(candidate.immutable());
+                    }
+                }
+            }
+        }
+        candidates.sort(Comparator.comparingDouble(candidate -> castScore(fromStance, candidate)));
+        for (BlockPos candidate : candidates) {
+            if (trajectoryClear(eye, candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private double castScore(BlockPos fromStance, BlockPos candidate) {
+        double dx = candidate.getX() - fromStance.getX();
+        double dz = candidate.getZ() - fromStance.getZ();
+        double horizontal = Math.sqrt(dx * dx + dz * dz);
+        return Math.abs(horizontal - IDEAL_CAST_DISTANCE)
+                + Math.abs(candidate.getY() - fromStance.getY()) * 0.35
+                - waterNeighbourCount(candidate) * 0.04;
+    }
+
+    private int waterNeighbourCount(BlockPos pos) {
+        int count = 0;
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                if (isCastableSurface(pos.offset(dx, 0, dz))) count++;
+            }
+        }
+        return count;
+    }
+
+    private boolean isCastableSurface(BlockPos pos) {
+        var fluid = player.level().getFluidState(pos);
+        if (!fluid.is(FluidTags.WATER) || !fluid.isSource()) return false;
+        if (player.level().getFluidState(pos.above()).is(FluidTags.WATER)) return false;
+        return player.level().getBlockState(pos.above())
+                .getCollisionShape(player.level(), pos.above()).isEmpty();
+    }
+
+    private boolean isDryStance(BlockPos pos) {
+        return player.level().getFluidState(pos).isEmpty()
+                && player.level().getFluidState(pos.above()).isEmpty()
+                && BlockHelper.canWalkThrough(player.level(), pos)
+                && BlockHelper.canWalkThrough(player.level(), pos.above())
+                && BlockHelper.canWalkOn(player.level(), pos.below());
+    }
+
+    private boolean atStance() {
+        return stance != null && feet().equals(stance) && isDryStance(stance);
+    }
+
+    private BlockPos feet() {
+        return BlockHelper.playerFeet(player.level(), player.getX(), player.getY(), player.getZ());
+    }
+
+    private void aimAtTarget() {
+        InputDriver.lookAt(player, castAimPoint(player.getEyePosition(), target));
+    }
+
+    private static Vec3 castAimPoint(Vec3 eye, BlockPos target) {
+        double tx = target.getX() + 0.5;
+        double tz = target.getZ() + 0.5;
+        double dx = tx - eye.x;
+        double dz = tz - eye.z;
+        double horizontal = Math.sqrt(dx * dx + dz * dz);
+        if (horizontal < 1.0e-6) return new Vec3(tx, waterSurfaceY(target), tz);
+        double pitch = Math.toRadians(castPitchDegrees(eye, target));
+        double scale = 16.0 / horizontal;
+        return new Vec3(eye.x + dx * scale,
+                eye.y - Math.tan(pitch) * 16.0,
+                eye.z + dz * scale);
+    }
+
+    private boolean trajectoryClear(Vec3 eye, BlockPos target) {
+        double tx = target.getX() + 0.5;
+        double tz = target.getZ() + 0.5;
+        double dx = tx - eye.x;
+        double dz = tz - eye.z;
+        double directDistance = Math.sqrt(dx * dx + dz * dz);
+        if (directDistance < 1.0e-6) return false;
+        double ux = dx / directDistance;
+        double uz = dz / directDistance;
+        // Vanilla spawns the bobber 0.3 blocks in front of the player's eyes.
+        Vec3 pos = eye.add(ux * 0.3, 0.0, uz * 0.3);
+        double distance = Math.sqrt((tx - pos.x) * (tx - pos.x) + (tz - pos.z) * (tz - pos.z));
+        double pitch = Math.toRadians(solvePitchDegrees(distance, waterSurfaceY(target) - eye.y));
+        double horizontalVelocity = 0.6 * Math.cos(pitch) + 0.5;
+        double verticalVelocity = -Math.tan(pitch) * horizontalVelocity;
+        double travelled = 0.0;
+
+        for (int tick = 0; tick < MAX_FLIGHT_TICKS; tick++) {
+            verticalVelocity -= FISHING_GRAVITY;
+            double fraction = Math.min(1.0, (distance - travelled) / horizontalVelocity);
+            Vec3 next = pos.add(ux * horizontalVelocity * fraction,
+                    verticalVelocity * fraction, uz * horizontalVelocity * fraction);
+            HitResult hit = player.level().clip(new ClipContext(pos, next,
+                    ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player));
+            if (hit.getType() != HitResult.Type.MISS) return false;
+            travelled += horizontalVelocity * fraction;
+            if (travelled >= distance - 1.0e-6) return true;
+            pos = next;
+            horizontalVelocity *= FISHING_DRAG;
+            verticalVelocity *= FISHING_DRAG;
+        }
+        return false;
+    }
+
+    private static double castPitchDegrees(Vec3 eye, BlockPos target) {
+        double dx = target.getX() + 0.5 - eye.x;
+        double dz = target.getZ() + 0.5 - eye.z;
+        double distance = Math.max(0.1, Math.sqrt(dx * dx + dz * dz) - 0.3);
+        return solvePitchDegrees(distance, waterSurfaceY(target) - eye.y);
+    }
+
+    static double solvePitchDegrees(double horizontalDistance, double targetHeight) {
+        double low = -45.0;
+        double high = 55.0;
+        for (int i = 0; i < 32; i++) {
+            double mid = (low + high) * 0.5;
+            double height = trajectoryHeightAtDistance(horizontalDistance, mid);
+            if (height > targetHeight) {
+                low = mid;  // trajectory is high: aim farther down
+            } else {
+                high = mid;
+            }
+        }
+        return (low + high) * 0.5;
+    }
+
+    static double trajectoryHeightAtDistance(double horizontalDistance, double pitchDegrees) {
+        double pitch = Math.toRadians(pitchDegrees);
+        double horizontalVelocity = 0.6 * Math.cos(pitch) + 0.5;
+        double verticalVelocity = -Math.tan(pitch) * horizontalVelocity;
+        double travelled = 0.0;
+        double height = 0.0;
+        for (int tick = 0; tick < MAX_FLIGHT_TICKS; tick++) {
+            verticalVelocity -= FISHING_GRAVITY;
+            double nextDistance = travelled + horizontalVelocity;
+            double nextHeight = height + verticalVelocity;
+            if (nextDistance >= horizontalDistance) {
+                double fraction = (horizontalDistance - travelled) / horizontalVelocity;
+                return height + verticalVelocity * fraction;
+            }
+            travelled = nextDistance;
+            height = nextHeight;
+            horizontalVelocity *= FISHING_DRAG;
+            verticalVelocity *= FISHING_DRAG;
+        }
+        return Double.NEGATIVE_INFINITY;
+    }
+
+    private static double waterSurfaceY(BlockPos target) {
+        return target.getY() + WATER_SURFACE_OFFSET;
+    }
+
+    static boolean isBiteWindow(int nibbleTicks) {
+        return nibbleTicks > 0;
+    }
+
+    private void discardHook() {
+        FishingHook hook = player.fishing;
+        if (hook != null) {
+            hook.discard();
+            if (player.fishing == hook) player.fishing = null;
+        }
+    }
+
+    @Override
+    public void suspend() {
+        boolean wasPositioning = phase == Phase.POSITION;
+        boolean wasCollecting = phase == Phase.COLLECT;
+        super.suspend();
+        discardHook();
+        if (wasCollecting) {
+            // Survival preemption may stop the navigator, but the already-caught
+            // drops remain the same bounded sub-goal when the LLM task resumes.
+            stopNav();
+        } else if (!wasPositioning) {
+            resetPositioning();
+        }
+    }
+
+    @Override
+    protected void cleanup() {
+        InputDriver.halt(player);
+        discardHook();
+        clearLootTracking();
+        super.cleanup();
+    }
+
+    @Override
+    protected Map<String, Object> resultData() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("requested", r.requested);
+        data.put("caught", r.caught());
+        data.put("casts", r.casts());
+        return data;
+    }
+
+    @Override
+    protected String successMessage() {
+        return "completed " + r.caught() + " successful fishing catch(es)";
+    }
+
+    @Override
+    protected String timeoutMessage() {
+        return "fishing timed out after " + r.caught() + "/" + r.requested + " successful catches";
+    }
+
+    @Override
+    protected String cancelledMessage() {
+        return "fishing interrupted after " + r.caught() + "/" + r.requested + " successful catches";
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/task/FishTaskRecord.java
+++ b/common/src/main/java/com/dwinovo/numen/core/task/FishTaskRecord.java
@@ -1,0 +1,40 @@
+package com.dwinovo.numen.core.task;
+
+import com.dwinovo.numen.task.TaskRecord;
+
+/** Typed descriptor and live progress for the {@code fish} background task. */
+public final class FishTaskRecord extends TaskRecord {
+
+    public static final String TOOL_NAME = "fish";
+
+    public final int requested;
+
+    private int caught;
+    private int casts;
+
+    public FishTaskRecord(String toolCallId, long deadlineGameTime, int requested) {
+        super(TOOL_NAME, toolCallId, deadlineGameTime);
+        this.requested = requested;
+    }
+
+    public int caught() {
+        return caught;
+    }
+
+    public int casts() {
+        return casts;
+    }
+
+    public void caughtOne() {
+        caught++;
+    }
+
+    public void castOnce() {
+        casts++;
+    }
+
+    @Override
+    public String describe() {
+        return TOOL_NAME + " " + caught + "/" + requested;
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/tools/FishTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/FishTool.java
@@ -1,0 +1,57 @@
+package com.dwinovo.numen.core.tools;
+
+import static com.dwinovo.numen.task.TaskDispatch.ctx;
+import static com.dwinovo.numen.task.TaskDispatch.dispatchAsync;
+
+import com.dwinovo.numen.agent.tool.NumenTool;
+import com.dwinovo.numen.agent.tool.Schema;
+import com.dwinovo.numen.core.task.FishTaskRecord;
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+/** Fish from a nearby water surface using the vanilla fishing-rod interaction. */
+public final class FishTool implements NumenTool {
+
+    private static final Gson GSON = new Gson();
+    private static final int MAX_COUNT = 64;
+    private static final long TICKS_PER_CATCH = 90L * 20L;
+    private static final long MIN_TIMEOUT_TICKS = 120L * 20L;
+
+    private record Args(int count) {}
+
+    @Override
+    public String name() {
+        return FishTaskRecord.TOOL_NAME;
+    }
+
+    @Override
+    public String description() {
+        return "Fish repeatedly from nearby water. Requires a vanilla fishing rod in inventory. "
+                + "If currently in water, moves up to 12 blocks onto a safe dry fishing stance; "
+                + "it does not search long-distance for a biome or water body. `count` is successful bites reeled in; "
+                + "vanilla fishing may produce fish, junk, or treasure. Uses native casting, loot, "
+                + "rod durability, sounds, and stats. BACKGROUND task: returns task_id immediately; "
+                + "the outcome arrives in task_finished.";
+    }
+
+    @Override
+    public Map<String, Object> parameterSchema() {
+        return Schema.object()
+                .integer("count", "Number of successful fishing bites to reel in.", 1, MAX_COUNT)
+                .build();
+    }
+
+    @Override
+    public void onServerCall(String toolCallId, JsonObject args, NumenPlayer companion,
+                             Consumer<String> reply) {
+        Args parsed = GSON.fromJson(args, Args.class);
+        int count = Math.clamp(parsed.count(), 1, MAX_COUNT);
+        long timeout = Math.max(MIN_TIMEOUT_TICKS, count * TICKS_PER_CATCH);
+        var context = ctx(toolCallId, companion);
+        dispatchAsync(companion, new FishTaskRecord(toolCallId, context.deadline(timeout), count), reply);
+    }
+}

--- a/common/src/main/resources/numen.mixins.json
+++ b/common/src/main/resources/numen.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.dwinovo.numen.core.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "FishingHookAccessor"
+  ],
+  "client": [],
+  "server": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/task/FishingRulesTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/task/FishingRulesTest.java
@@ -1,0 +1,36 @@
+package com.dwinovo.numen.core.task;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FishingRulesTest {
+
+    @Test
+    void ignoresTheHookBeforeVanillaOpensTheBiteWindow() {
+        assertFalse(FishCompanionTask.isBiteWindow(0));
+        assertFalse(FishCompanionTask.isBiteWindow(-1));
+    }
+
+    @Test
+    void detectsVanillasPrivateNibbleWindowDirectly() {
+        assertTrue(FishCompanionTask.isBiteWindow(1));
+        assertTrue(FishCompanionTask.isBiteWindow(40));
+    }
+
+    @Test
+    void ballisticPitchLandsAtTheRequestedHeight() {
+        double pitch = FishCompanionTask.solvePitchDegrees(6.3, -1.62);
+        assertEquals(-1.62,
+                FishCompanionTask.trajectoryHeightAtDistance(6.3, pitch), 1.0e-5);
+    }
+
+    @Test
+    void longerCastsNeedMoreElevationAboveTheWater() {
+        double shortPitch = FishCompanionTask.solvePitchDegrees(4.3, -1.62);
+        double longPitch = FishCompanionTask.solvePitchDegrees(9.3, -1.62);
+        assertTrue(longPitch < shortPitch);
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,6 +25,9 @@
             "com.dwinovo.numen.core.data.FabricDataGenerators"
         ]
     },
+    "mixins": [
+        "${mod_id}.mixins.json"
+    ],
     "depends": {
         "fabricloader": ">=${fabric_loader_version}",
         "fabric-api": "*",

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -9,6 +9,8 @@ logoFile="${mod_id}.png" #optional
 credits="${credits}" #optional
 authors = "${mod_author}" #optional
 description = '''${description}''' #mandatory (Supports multiline text)
+[[mixins]]
+config = "${mod_id}.mixins.json"
 [[dependencies.${mod_id}]] #optional
 modId = "numen_api" #mandatory — core supplies tools to the numen-api engine
 type="required" #mandatory


### PR DESCRIPTION
## TL;DR

### 背景 / Why

实机测试发现，AI 虽然可以使用现有的通用工具装备鱼竿、寻找水域并进行右键交互，但无法可靠地完成钓鱼。

钓鱼需要持续监控鱼钩状态，并在很短的原版咬钩窗口内收杆。当前的 LLM Agent Loop 更适合秒级的规划与工具调用，不适合逐 tick 观察鱼钩。AI 因此只能猜测等待时间，经常过早收杆、反复调整站位，最终无法完成任务。

这不是规划能力的问题，而是缺少一个能够在游戏 tick 内持续运行、读取原版钓鱼状态的确定性工具。因此本 PR 将实时钓鱼过程封装为后台 `fish(count)` 任务：LLM 只负责决定何时钓鱼以及目标数量，具体的站位、抛竿、等待咬钩、收杆和拾取由任务代码完成。

### 实现内容

- 自动装备背包中的鱼竿。
- 在附近寻找安全的岸上站位；角色在水中时可自行上岸。
- 检查水面、抛竿距离及弹道遮挡，并计算合适的抛竿角度。
- 通过只读 Mixin Accessor 读取原版 `FishingHook.nibble`，准确捕捉真实咬钩窗口，而非依赖固定延迟。
- 使用原版交互完成抛竿和收杆，保留耐久、音效、统计及原版战利品规则。
- 区分本次钓鱼产生的渔获与地面原有物品；等待渔获飞回，必要时寻路拾取。
- 对错误落点、路径失败、无鱼竿和渔获无法拾取等情况进行有限重试并返回明确错误，避免无限循环。
- 支持任务暂停、取消和状态清理。

工具只负责附近水域的实际钓鱼，不负责远距离寻找水域、制作鱼竿。

以上是AI总结，我在1.21.1 Fabric中进行了测试，效果如描述所说，可以稳定地连续钓鱼。

以下是实现细节，顺便说下老哥你这玩意做的好啊 0v0

---

## Summary

Adds a new background `fish` tool that lets the companion perform repeated vanilla fishing:

```text
fish(count)
```

`count` represents successful catches reeled in. A catch may be fish, junk, or treasure according to vanilla fishing rules.

## Features

- Automatically finds and equips a fishing rod from the inventory.
- Searches for a safe dry fishing stance near the current position.
- Can move out of water and return to a nearby shoreline before fishing.
- Finds a valid water-source surface with clear space above it.
- Calculates the casting pitch using the fishing hook's vanilla projectile trajectory.
- Checks the cast trajectory for block collisions before casting.
- Uses the normal vanilla rod interaction, preserving:
  - rod durability
  - sounds and animations
  - statistics
  - vanilla loot tables and fishing rules
- Detects the actual vanilla bite window and reels in at the correct time.
- Repeats until the requested number of successful catches is reached.
- Returns progress and result data including requested catches, completed catches, and cast count.

## Positioning and cast handling

The task performs several checks before casting:

- The stance must be dry, walkable, and have enough space for the player.
- The water target must be a source block at the water surface.
- The space above the target must be unobstructed.
- The target must be within the supported casting distance.
- The simulated hook trajectory must reach the selected water block without colliding with terrain.

Invalid or obstructed targets are rejected. Failed casts are retried with another target where possible, with a bounded retry limit and actionable failure messages.

The tool only handles nearby water. It does not perform long-distance exploration for a biome or water body.

## Bite detection

Vanilla's successful-bite countdown (`FishingHook.nibble`) is private and does not expose a suitable public callback.

This PR adds a read-only Mixin accessor for that field. It allows the task to react to the real vanilla bite window instead of relying on particles, fixed delays, or timing guesses.

The accessor does not modify fishing state or vanilla fishing behavior.

## Catch retrieval

Reeling in is not treated as complete until the resulting dropped loot has been handled.

The task:

- Records nearby item entities before reeling.
- Tracks only item entities introduced by the successful reel, avoiding unrelated ground items.
- Waits briefly for vanilla's reel impulse to bring the catch back naturally.
- Collects the catch normally if it reaches the companion.
- Navigates toward stranded loot when terrain, slabs, or shoreline geometry stops it short.
- Reports a failure instead of looping indefinitely if the dropped loot is unreachable or cannot be picked up.

## Failure handling

The task reports explicit failures for cases such as:

- no fishing rod in the inventory
- no safe dry stance near reachable water
- unreachable shoreline positions
- obstructed or unsuccessful casts
- the hook landing outside water
- the hook catching an entity
- no bite before timeout
- dropped fishing loot being unreachable

Hooks and movement state are also cleaned up when the task is cancelled, suspended, fails, or completes.

## Scope

The tool intentionally does not:

- locate distant water or suitable biomes
- craft or acquire a fishing rod
- predict the resulting loot
- enforce open-water conditions for treasure fishing

Those decisions remain with the caller and vanilla game rules.

## Validation

- Added unit tests for bite-window detection and ballistic casting calculations.
- Verified with:

```text
./gradlew test build
```

- Tested in-game on Minecraft 1.21.1 with both Fabric build.
- Manually verified:
  - moving from water onto a dry shoreline
  - successful casting into water
  - waiting for a real bite
  - reeling in repeated catches
  - collecting catches that land away from the companion
  - continuing automatically until the requested count is reached