### PR TITLE
fix(tools): tighten planning and background contracts

### DIFF
--- a/common/src/main/java/com/dwinovo/numen/core/tools/AgentTools.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/AgentTools.java
@@ -66,11 +66,18 @@ String priority) {}
 
     public String todowrite(
 List<Todo> todos) {
+        if (todos == null) {
+            throw new IllegalArgumentException("todos is required");
+        }
         int inProgressCount = 0;
+        boolean workRemains = false;
         // Echo back the canonical JSON; the model reads it next turn as its plan.
         JsonArray echo = new JsonArray();
         for (int i = 0; i < todos.size(); i++) {
             Todo t = todos.get(i);
+            if (t == null || t.content() == null || t.content().isBlank()) {
+                throw new IllegalArgumentException("todos[" + i + "].content must not be blank");
+            }
             if (!ALLOWED_STATUSES.contains(t.status())) {
                 throw new IllegalArgumentException(
                         "todos[" + i + "].status must be one of " + ALLOWED_STATUSES + ", got: " + t.status());
@@ -80,6 +87,7 @@ List<Todo> todos) {
                         "todos[" + i + "].priority must be one of " + ALLOWED_PRIORITIES + ", got: " + t.priority());
             }
             if ("in_progress".equals(t.status())) inProgressCount++;
+            if ("in_progress".equals(t.status()) || "pending".equals(t.status())) workRemains = true;
             JsonObject o = new JsonObject();
             o.addProperty("content", t.content());
             o.addProperty("status", t.status());
@@ -87,10 +95,11 @@ List<Todo> todos) {
             echo.add(o);
         }
         String echoed = echo.toString();
-        if (inProgressCount > 1) {
-            return "{\"success\":true,\"warning\":\"more than one todo in_progress ("
-                    + inProgressCount + "); keep exactly one\",\"todos\":" + echoed + "}";
+        if (workRemains && inProgressCount != 1) {
+            return "{\"success\":false,\"message\":\"unfinished work requires exactly one todo in_progress; got "
+                    + inProgressCount + "\",\"todos\":" + echoed + "}";
         }
-        return "{\"success\":true,\"todos\":" + echoed + "}";
+        return "{\"success\":true,\"message\":\"plan snapshot replaced; continue only the in_progress item\",\"todos\":"
+                + echoed + "}";
     }
 }

--- a/common/src/main/java/com/dwinovo/numen/core/tools/AutoMineTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/AutoMineTool.java
@@ -34,8 +34,14 @@ public final class AutoMineTool implements NumenTool {
                 + "blocks (redstone_ore drops ~4). Include all variants in block_ids (iron_ore AND "
                 + "deepslate_iron_ore). Only mines what its tools actually harvest, and stops naming the "
                 + "needed tier if nothing qualifies (to destroy blocks regardless of drops, use "
-                + "break_block). BACKGROUND task: returns a task_id at once; the outcome arrives as a "
-                + "task_finished event — don't poll.";
+                + "break_block). BACKGROUND: a successful call is already running; do not call mine/goto "
+                + "again while <current_task> exists and do not poll. task_finished status=done means the "
+                + "requested count is complete; only timeout permits resending the same arguments.";
+    }
+
+    /** Layer-one summary used by numen-api versions with progressive tool disclosure. */
+    public String summary() {
+        return "Find and gather a requested item count from named block variants as one background job; no goto or polling needed.";
     }
 
     @Override

--- a/common/src/main/java/com/dwinovo/numen/core/tools/BuildTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/BuildTool.java
@@ -54,7 +54,13 @@ public final class BuildTool implements NumenTool {
                 + "CLEARS/breaks whatever is there (drops harvest normally). The task walks, climbs and bridges to "
                 + "each cell, clears wrong blocks at requested cells when replacement is enabled, and can build in "
                 + "optional vertical layers. Use this for a single block, a correction, or portals, frames, walls, "
-                + "stairs, pillars, roofs and larger construction. It does not read schematic files yet.";
+                + "stairs, pillars, roofs and larger construction. It does not read schematic files yet. BACKGROUND: "
+                + "after acceptance, wait for task_finished and never resend the same cell list while it is running or after status=done.";
+    }
+
+    /** Layer-one summary used by numen-api versions with progressive tool disclosure. */
+    public String summary() {
+        return "Place/clear 1-512 explicit absolute block cells from inventory as one background construction job.";
     }
 
     @Override

--- a/common/src/main/java/com/dwinovo/numen/core/tools/CollectItemsTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/CollectItemsTool.java
@@ -32,7 +32,12 @@ public final class CollectItemsTool implements NumenTool {
                 + "handled automatically: it digs and bridges on its own if drops landed in a pit or "
                 + "across a gap. Optionally restrict to specific item_ids (omit to collect everything). "
                 + "Optional radius (default 16). Use after ranged combat or manual interactions; melee_attack collects its own drops. "
-                + "BACKGROUND task: returns a task_id at once; the tally arrives as a task_finished event.";
+                + "BACKGROUND: acceptance means collection is already running; wait for task_finished, do not poll or resend unchanged.";
+    }
+
+    /** Layer-one summary used by numen-api versions with progressive tool disclosure. */
+    public String summary() {
+        return "Collect nearby dropped item entities, optionally filtered, as one background pickup job.";
     }
 
     @Override

--- a/common/src/main/java/com/dwinovo/numen/core/tools/MeleeAttackTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/MeleeAttackTool.java
@@ -28,8 +28,13 @@ public final class MeleeAttackTool implements NumenTool {
                 + "scan_nearby_entities. Tracks moving targets with the full pathfinder, uses "
                 + "nearest-target selection, visible aiming, vanilla cooldown attacks and weapon switching, "
                 + "then picks up each target's drops before moving on. Players and mobs use the same ids. "
-                + "BACKGROUND task: returns task_id immediately; per-target outcomes and loot arrive in "
-                + "task_finished.";
+                + "BACKGROUND: acceptance means combat is already running; do not resend ids, poll, or launch "
+                + "another body action until task_finished reports the terminal outcome.";
+    }
+
+    /** Layer-one summary used by numen-api versions with progressive tool disclosure. */
+    public String summary() {
+        return "Melee-attack specific current runtime entity ids and collect their drops as one background job.";
     }
 
     @Override

--- a/common/src/main/java/com/dwinovo/numen/core/tools/MoveToTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/MoveToTool.java
@@ -27,12 +27,17 @@ public final class MoveToTool implements NumenTool {
     @Override
     public String description() {
         return """
-                Travel anywhere. Full pathfinding: digs through, bridges gaps, pillars up, swims, auto-equips the right tool. Anything breakable is a route (no tool = slow punching, still works). Which fields you fill IS your intent — fill exactly one pattern:
-                • x+z — go to a place. Y resolves to the surface. Your default for "go there".
-                • block — e.g. block:'crafting_table'. Finds the nearest one and stops RIGHT BESIDE it, never damaging it. Always use this for a chest/station/ore you intend to use; you arrive in reach, interact directly.
-                • x+y+z — stand EXACTLY in that cell, digging out whatever occupies it. Never aim this at a block you want to keep.
+                Travel to ONE new destination with full terrain pathfinding: digs through, bridges gaps, pillars up, swims, and auto-equips tools. Which fields you fill IS your intent — fill exactly one pattern:
+                • x+z — go to a place. Y resolves to the surface. This is the DEFAULT for exploration or "go there"; omit y.
+                • block — e.g. block:'minecraft:crafting_table'. Finds the nearest one and stops RIGHT BESIDE it, never damaging it. Use this for a chest/station/block you intend to interact with.
+                • x+y+z — stand EXACTLY in that cell, digging out whatever occupies it. Use only when the exact feet cell matters; never aim it at a block you want to keep.
                 • y — climb/descend to that elevation.
-                Background task: returns task_id now, arrival comes as a task_finished event with the final position. Timed out mid-journey? Re-send the same call to continue.""";
+                BACKGROUND: a successful call means movement is already running. Do not call goto again or launch another body action while <current_task> exists; wait for matching task_finished. status=done means that destination is complete, so advance the plan and never resend identical coordinates. Only status=timeout permits the same call to resume.""";
+    }
+
+    /** Layer-one summary used by numen-api versions with progressive tool disclosure. */
+    public String summary() {
+        return "Travel once to a new coordinate/elevation or beside a named block; background and never repeat an already running/completed destination.";
     }
 
     @Override

--- a/common/src/main/java/com/dwinovo/numen/core/tools/RangedAttackTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/RangedAttackTool.java
@@ -32,8 +32,13 @@ public final class RangedAttackTool implements NumenTool {
                 + "targets with the pathfinder until an arrow can hit, backs away when too close, "
                 + "aims visibly, fires only after the shot path is clear, and stops with a clear "
                 + "failure if no bow/crossbow or arrows are available. Targets may be living entities "
-                + "or breakable non-living entities such as end crystals. BACKGROUND task: returns "
-                + "task_id immediately; per-target outcomes arrive in task_finished.";
+                + "or breakable non-living entities such as end crystals. BACKGROUND: acceptance means combat "
+                + "is already running; do not resend ids, poll, or launch another body action until task_finished.";
+    }
+
+    /** Layer-one summary used by numen-api versions with progressive tool disclosure. */
+    public String summary() {
+        return "Ranged-attack specific current runtime entity ids with a bow/crossbow as one background job.";
     }
 
     @Override

--- a/common/src/main/java/com/dwinovo/numen/core/tools/TodoWriteTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/TodoWriteTool.java
@@ -25,7 +25,7 @@ public final class TodoWriteTool implements NumenTool {
     @Override
     public String description() {
         return """
-                Maintain a structured todo list for multi-step work (3+ distinct steps or several sub-tasks); skip it for single actions and chit-chat. Each call replaces the whole list. Keep exactly ONE item in_progress while work remains; mark completed only after the work is actually done (never on intent), in real time rather than batched; if blocked, keep it in_progress and add a follow-up describing the blocker.""";
+                Maintain the durable active plan for multi-step work (3+ distinct physical phases or several sub-tasks); skip single actions and chit-chat. Call it BEFORE the first physical step, then immediately after every verified result/task_finished to mark the finished phase and advance exactly ONE item to in_progress. Each call replaces the whole list. Never reset completed items on "continue/resume", never mark work complete on intent/dispatch, and never leave a just-completed background step in_progress. If blocked, keep it in_progress and add a concrete recovery item.""";
     }
 
     @Override

--- a/common/src/test/java/com/dwinovo/numen/core/tools/AgentToolsTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/tools/AgentToolsTest.java
@@ -1,0 +1,59 @@
+package com.dwinovo.numen.core.tools;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentToolsTest {
+
+    private final AgentTools tools = new AgentTools();
+
+    @Test
+    void acceptsExactlyOneInProgressWhileWorkRemains() {
+        String result = tools.todowrite(List.of(
+                todo("find iron", "in_progress"),
+                todo("mine iron", "pending"),
+                todo("get pickaxe", "completed")));
+
+        assertTrue(success(result));
+        assertTrue(result.contains("continue only the in_progress item"));
+    }
+
+    @Test
+    void rejectsPlansWithZeroOrSeveralInProgressItems() {
+        assertFalse(success(tools.todowrite(List.of(
+                todo("find iron", "pending"),
+                todo("mine iron", "pending")))));
+        assertFalse(success(tools.todowrite(List.of(
+                todo("find iron", "in_progress"),
+                todo("mine iron", "in_progress")))));
+    }
+
+    @Test
+    void allTerminalOrEmptyPlanIsValid() {
+        assertTrue(success(tools.todowrite(List.of(
+                todo("find iron", "completed"),
+                todo("mine iron", "cancelled")))));
+        assertTrue(success(tools.todowrite(List.of())));
+    }
+
+    @Test
+    void rejectsMissingOrBlankPlanContent() {
+        assertThrows(IllegalArgumentException.class, () -> tools.todowrite(null));
+        assertThrows(IllegalArgumentException.class, () ->
+                tools.todowrite(List.of(todo(" ", "in_progress"))));
+    }
+
+    private static AgentTools.Todo todo(String content, String status) {
+        return new AgentTools.Todo(content, status, "medium");
+    }
+
+    private static boolean success(String json) {
+        return JsonParser.parseString(json).getAsJsonObject().get("success").getAsBoolean();
+    }
+}


### PR DESCRIPTION
## Summary

- tighten `goto`, `mine`, `build`, dropped-item collection, melee, and ranged-combat descriptions around their background-task lifecycle
- state clearly that acceptance means the task is already running, callers should not poll/re-dispatch, `done` advances the plan, and only `timeout` permits an unchanged resume
- provide concise forward-compatible layer-one summaries for progressive tool disclosure
- clarify `task_finished`, `task_status`, and `task_stop` cards exposed by the core tool catalogue
- make `todowrite` validation require exactly one `in_progress` item whenever unfinished work remains
- replace the stale `auto_mine` prompt reference with the real `mine` tool
- add focused contract and validation tests

## Related engine change

Complements Dwinovo/numen-api#7. The source remains compatible with the currently published API; its summary methods automatically override the new API default once progressive disclosure is available.

## Scope

Based directly on the current upstream `1.21.1` branch. It does not contain the local NeoForge-loader compatibility commit, visual documentation branch, or any engine JAR changes.

## Validation

- 226 common tests passed
- Fabric and NeoForge full builds passed
- after rebasing to the current upstream release head, common tests and both loader compilations passed again