### PR TITLE
feat: 添加可选的主人自动跟随功能

### DIFF
--- a/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
@@ -12,6 +12,8 @@ import com.dwinovo.numen.network.payload.ExecuteToolPayload;
 import com.dwinovo.numen.network.payload.TaskResultPayload;
 import com.dwinovo.numen.task.CompanionTaskFactory;
 import com.dwinovo.numen.task.CompanionTickDispatcher;
+import com.dwinovo.numen.core.follow.FollowConfig;
+import com.dwinovo.numen.core.follow.FollowOwnerTool;
 import com.dwinovo.numen.core.follow.FollowReleaseReason;
 import com.dwinovo.numen.core.follow.FollowService;
 import com.dwinovo.numen.core.task.BuildCompanionTask;
@@ -70,10 +72,11 @@ public final class NumenCore {
     public static void init() {
         if (initialised) return;
         initialised = true;
+        FollowConfig followConfig = FollowConfig.current();
         registerFollowLifecycle();
-        registerTools();
+        registerTools(followConfig);
         registerTaskRunners();
-        registerChains();
+        registerChains(followConfig);
         registerReflexes();
         // Enable the autonomous survival chains (auto-eat / mob-defense / unstuck /
         // MLG). SurvivalConfig's own default is OFF — the safe state a bare library
@@ -106,7 +109,7 @@ public final class NumenCore {
      * 把 core 的五条生存本能链插进引擎的竞价调度(链登记口)。运输包与
      * 生命周期对接已随排程机器归引擎,不再是 core 的事。
      */
-    private static void registerChains() {
+    private static void registerChains(FollowConfig followConfig) {
         com.dwinovo.numen.task.BrainChains.register(10,
                 bodyLog -> new com.dwinovo.numen.core.task.chain.UnstuckChain());
         com.dwinovo.numen.task.BrainChains.register(20,
@@ -118,7 +121,8 @@ public final class NumenCore {
         com.dwinovo.numen.task.BrainChains.register(50,
                 com.dwinovo.numen.core.task.chain.BreathChain::new);
         com.dwinovo.numen.task.BrainChains.register(60,
-                bodyLog -> new com.dwinovo.numen.core.follow.OwnerFollowChain());
+                bodyLog -> new com.dwinovo.numen.core.follow.OwnerFollowChain(
+                        followConfig));
     }
 
     /**
@@ -131,10 +135,11 @@ public final class NumenCore {
         com.dwinovo.numen.core.task.reflex.CoreReflexes.registerAll();
     }
 
-    private static void registerTools() {
+    private static void registerTools(FollowConfig followConfig) {
 
         // Registration ORDER is preserved (backends with prompt-caching keyed off
         // the tool list cache stably across requests).
+        ToolRegistry.register(new FollowOwnerTool(followConfig));
         ToolRegistry.register(new com.dwinovo.numen.core.tools.MoveToTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.MeleeAttackTool());
         ToolRegistry.register(new com.dwinovo.numen.core.tools.RangedAttackTool());

--- a/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
@@ -92,6 +92,8 @@ public final class NumenCore {
                 com.dwinovo.numen.core.task.chain.MLGChain::new);
         com.dwinovo.numen.task.BrainChains.register(50,
                 com.dwinovo.numen.core.task.chain.BreathChain::new);
+        com.dwinovo.numen.task.BrainChains.register(60,
+                bodyLog -> new com.dwinovo.numen.core.follow.OwnerFollowChain());
     }
 
     /**

--- a/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
@@ -101,7 +101,7 @@ public final class NumenCore {
             NumenPlayer companion, FollowReleaseReason reason) {
         MinecraftServer server = companion.level().getServer();
         if (server != null) {
-            FollowService.removeRuntime(server, companion.getUUID(), reason);
+            FollowService.removeRuntime(server, companion, reason);
         }
     }
 

--- a/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/NumenCore.java
@@ -12,6 +12,8 @@ import com.dwinovo.numen.network.payload.ExecuteToolPayload;
 import com.dwinovo.numen.network.payload.TaskResultPayload;
 import com.dwinovo.numen.task.CompanionTaskFactory;
 import com.dwinovo.numen.task.CompanionTickDispatcher;
+import com.dwinovo.numen.core.follow.FollowReleaseReason;
+import com.dwinovo.numen.core.follow.FollowService;
 import com.dwinovo.numen.core.task.BuildCompanionTask;
 import com.dwinovo.numen.core.task.BuildTaskRecord;
 import com.dwinovo.numen.core.task.CollectItemsTaskGoal;
@@ -38,6 +40,9 @@ import com.dwinovo.numen.core.task.MineBlockTaskRecord;
 import com.dwinovo.numen.core.task.MineCompanionTask;
 import com.dwinovo.numen.core.task.MoveToCompanionTask;
 import com.dwinovo.numen.core.task.MoveToTaskRecord;
+import com.dwinovo.numen.entity.NumenPlayer;
+
+import net.minecraft.server.MinecraftServer;
 
 /**
  * Loader-agnostic init for the {@code numen-core} tool pack — the worked example
@@ -65,6 +70,7 @@ public final class NumenCore {
     public static void init() {
         if (initialised) return;
         initialised = true;
+        registerFollowLifecycle();
         registerTools();
         registerTaskRunners();
         registerChains();
@@ -75,6 +81,25 @@ public final class NumenCore {
         com.dwinovo.numen.core.task.SurvivalConfig.setEnabled(true);
         Constants.LOG.info("[numen-core] registered {} tool(s), {} task type(s); survival chains enabled",
                 ToolRegistry.size(), CompanionTaskFactory.size());
+    }
+
+    /**
+     * Releases the transient runtime before the API removes the companion body.
+     * Persistent follow intent is deliberately untouched.
+     */
+    private static void registerFollowLifecycle() {
+        CompanionLifecycle.onDeath(companion ->
+                removeFollowRuntime(companion, FollowReleaseReason.COMPANION_DEATH));
+        CompanionLifecycle.onRemove(companion ->
+                removeFollowRuntime(companion, FollowReleaseReason.COMPANION_REMOVED));
+    }
+
+    private static void removeFollowRuntime(
+            NumenPlayer companion, FollowReleaseReason reason) {
+        MinecraftServer server = companion.level().getServer();
+        if (server != null) {
+            FollowService.removeRuntime(server, companion.getUUID(), reason);
+        }
     }
 
     /**

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowAction.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowAction.java
@@ -1,0 +1,30 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * User-facing owner-follow controls shared by commands and the body-bound tool.
+ */
+public enum FollowAction {
+    ON,
+    OFF,
+    PAUSE,
+    RESUME,
+    STATUS;
+
+    public static Optional<FollowAction> parse(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(valueOf(value.trim().toUpperCase(Locale.ROOT)));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    public String argumentValue() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowCommands.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowCommands.java
@@ -1,0 +1,202 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Fabric-registered owner-only subtree merged into the existing {@code /numen}
+ * root.
+ */
+public final class FollowCommands {
+
+    static final String COMPANION_ARGUMENT = "companion_name";
+    static final String ACTION_ARGUMENT = "action";
+
+    private FollowCommands() {}
+
+    public static void register(
+            CommandDispatcher<CommandSourceStack> dispatcher,
+            FollowConfig config) {
+        Objects.requireNonNull(dispatcher, "dispatcher");
+        Objects.requireNonNull(config, "config");
+        dispatcher.register(Commands.literal("numen")
+                .then(Commands.literal("follow")
+                        .then(Commands.argument(
+                                COMPANION_ARGUMENT,
+                                        StringArgumentType.word())
+                                .suggests(FollowCommands::suggestOwnedCompanions)
+                                .then(Commands.argument(
+                                                ACTION_ARGUMENT,
+                                                StringArgumentType.word())
+                                        .suggests((context, builder) -> {
+                                            for (FollowAction action
+                                                    : FollowAction.values()) {
+                                                builder.suggest(
+                                                        action.argumentValue());
+                                            }
+                                            return builder.buildFuture();
+                                        })
+                                        .executes(context ->
+                                                executeParsed(context, config))))));
+    }
+
+    private static int executeParsed(
+            CommandContext<CommandSourceStack> context,
+            FollowConfig config) throws CommandSyntaxException {
+        String rawAction = StringArgumentType.getString(
+                context, ACTION_ARGUMENT);
+        FollowAction action = FollowAction.parse(rawAction).orElse(null);
+        if (action == null) {
+            context.getSource().sendFailure(Component.literal(
+                    "未知 follow action；只能使用 on、off、pause、resume 或 status。"));
+            return 0;
+        }
+        return execute(context, action, config);
+    }
+
+    private static int execute(
+            CommandContext<CommandSourceStack> context,
+            FollowAction action,
+            FollowConfig config) throws CommandSyntaxException {
+        ServerPlayer owner = context.getSource().getPlayerOrException();
+        NumenPlayer companion = requireOwnedCompanion(context, owner);
+        if (companion == null) {
+            return 0;
+        }
+        FollowControlResult result = FollowService.apply(
+                owner.level().getServer(), companion, action, config);
+        Component feedback = Component.literal(
+                result.message() + "\n" + result.status().compactText());
+        if (!result.success()) {
+            context.getSource().sendFailure(feedback);
+            return 0;
+        }
+        context.getSource().sendSuccess(() -> feedback, false);
+        return 1;
+    }
+
+    private static java.util.concurrent.CompletableFuture<
+            com.mojang.brigadier.suggestion.Suggestions>
+            suggestOwnedCompanions(
+                    CommandContext<CommandSourceStack> context,
+                    com.mojang.brigadier.suggestion.SuggestionsBuilder builder) {
+        ServerPlayer owner = context.getSource().getPlayer();
+        if (owner != null) {
+            owner.level().getServer().getPlayerList().getPlayers().stream()
+                    .filter(NumenPlayer.class::isInstance)
+                    .map(NumenPlayer.class::cast)
+                    .filter(companion -> companion.getOwnerUuid() != null
+                            && companion.getOwnerUuid().equals(owner.getUUID()))
+                    .map(companion -> companion.getName().getString())
+                    .distinct()
+                    .forEach(builder::suggest);
+        }
+        return builder.buildFuture();
+    }
+
+    private static NumenPlayer requireOwnedCompanion(
+            CommandContext<CommandSourceStack> context,
+            ServerPlayer owner) {
+        String name = StringArgumentType.getString(
+                context, COMPANION_ARGUMENT);
+        List<NumenPlayer> online = new ArrayList<>();
+        for (ServerPlayer player
+                : owner.level().getServer().getPlayerList().getPlayers()) {
+            if (player instanceof NumenPlayer companion) {
+                online.add(companion);
+            }
+        }
+        Resolution<NumenPlayer> resolution = resolveOwnedByName(
+                online,
+                owner.getUUID(),
+                name,
+                companion -> companion.getName().getString(),
+                NumenPlayer::getOwnerUuid);
+        return switch (resolution.code()) {
+            case FOUND -> resolution.value();
+            case INVALID_NAME -> {
+                context.getSource().sendFailure(Component.literal(
+                        "必须明确填写同伴名称；不支持 all 或 UUID 文本。"));
+                yield null;
+            }
+            case NOT_FOUND -> {
+                context.getSource().sendFailure(Component.literal(
+                        "没有属于你且在线、名称为 '" + name + "' 的同伴。"));
+                yield null;
+            }
+            case AMBIGUOUS -> {
+                context.getSource().sendFailure(Component.literal(
+                        "名称 '" + name + "' 匹配多个你的在线同伴，请先使用唯一名称。"));
+                yield null;
+            }
+        };
+    }
+
+    static <T> Resolution<T> resolveOwnedByName(
+            List<T> online,
+            UUID ownerUuid,
+            String requestedName,
+            Function<T, String> name,
+            Function<T, UUID> owner) {
+        Objects.requireNonNull(online, "online");
+        Objects.requireNonNull(ownerUuid, "ownerUuid");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(owner, "owner");
+        if (requestedName == null
+                || requestedName.isBlank()
+                || requestedName.equalsIgnoreCase("all")
+                || isUuidText(requestedName)) {
+            return new Resolution<>(ResolutionCode.INVALID_NAME, null);
+        }
+
+        T match = null;
+        for (T candidate : online) {
+            if (requestedName.equals(name.apply(candidate))
+                    && ownerUuid.equals(owner.apply(candidate))) {
+                if (match != null) {
+                    return new Resolution<>(ResolutionCode.AMBIGUOUS, null);
+                }
+                match = candidate;
+            }
+        }
+        return match == null
+                ? new Resolution<>(ResolutionCode.NOT_FOUND, null)
+                : new Resolution<>(ResolutionCode.FOUND, match);
+    }
+
+    private static boolean isUuidText(String value) {
+        try {
+            UUID.fromString(value);
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
+    }
+
+    enum ResolutionCode {
+        FOUND,
+        NOT_FOUND,
+        AMBIGUOUS,
+        INVALID_NAME
+    }
+
+    record Resolution<T>(ResolutionCode code, T value) {
+        Resolution {
+            Objects.requireNonNull(code, "code");
+        }
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowConfig.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowConfig.java
@@ -1,0 +1,274 @@
+package com.dwinovo.numen.core.follow;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.dwinovo.numen.core.Constants;
+import com.dwinovo.numen.platform.Services;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Immutable, startup-scoped owner-follow configuration.
+ *
+ * <p>Unsafe world-changing capabilities are represented so an accidental
+ * {@code true} in the user file can be diagnosed, but every effective instance
+ * clamps those capabilities to {@code false}.
+ */
+public record FollowConfig(
+        double stopDistance,
+        double startDistance,
+        double sprintDistance,
+        double catchUpDistance,
+        double lostDistance,
+        long failedCooldownTicks,
+        boolean allowBreak,
+        boolean allowPlace,
+        boolean allowWaterBucketLanding,
+        boolean allowTeleport,
+        boolean allowCrossDimension) {
+
+    public static final double DEFAULT_STOP_DISTANCE = 3.0;
+    public static final double DEFAULT_START_DISTANCE = 5.5;
+    public static final double DEFAULT_SPRINT_DISTANCE = 12.0;
+    public static final double DEFAULT_CATCH_UP_DISTANCE = 24.0;
+    public static final double DEFAULT_LOST_DISTANCE = 64.0;
+    public static final long DEFAULT_FAILED_COOLDOWN_TICKS = 100L;
+
+    public static final String FILE_NAME = "auto_follow.json";
+
+    private static final String STOP_DISTANCE = "stop_distance";
+    private static final String START_DISTANCE = "start_distance";
+    private static final String SPRINT_DISTANCE = "sprint_distance";
+    private static final String CATCH_UP_DISTANCE = "catch_up_distance";
+    private static final String LOST_DISTANCE = "lost_distance";
+    private static final String FAILED_COOLDOWN_TICKS = "failed_cooldown_ticks";
+    private static final String ALLOW_BREAK = "allow_break";
+    private static final String ALLOW_PLACE = "allow_place";
+    private static final String ALLOW_WATER_BUCKET_LANDING =
+            "allow_water_bucket_landing";
+    private static final String ALLOW_TELEPORT = "allow_teleport";
+    private static final String ALLOW_CROSS_DIMENSION = "allow_cross_dimension";
+
+    private static final Pattern INTEGER_TOKEN = Pattern.compile("-?(0|[1-9][0-9]*)");
+    private static final BigInteger MAX_COOLDOWN =
+            BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final Gson PRETTY =
+            new GsonBuilder().setPrettyPrinting().create();
+
+    public FollowConfig {
+        if (!validNumericSet(stopDistance, startDistance, sprintDistance,
+                catchUpDistance, lostDistance, failedCooldownTicks)) {
+            stopDistance = DEFAULT_STOP_DISTANCE;
+            startDistance = DEFAULT_START_DISTANCE;
+            sprintDistance = DEFAULT_SPRINT_DISTANCE;
+            catchUpDistance = DEFAULT_CATCH_UP_DISTANCE;
+            lostDistance = DEFAULT_LOST_DISTANCE;
+            failedCooldownTicks = DEFAULT_FAILED_COOLDOWN_TICKS;
+        }
+        allowBreak = false;
+        allowPlace = false;
+        allowWaterBucketLanding = false;
+        allowTeleport = false;
+        allowCrossDimension = false;
+    }
+
+    public static FollowConfig defaults() {
+        return new FollowConfig(
+                DEFAULT_STOP_DISTANCE,
+                DEFAULT_START_DISTANCE,
+                DEFAULT_SPRINT_DISTANCE,
+                DEFAULT_CATCH_UP_DISTANCE,
+                DEFAULT_LOST_DISTANCE,
+                DEFAULT_FAILED_COOLDOWN_TICKS,
+                false, false, false, false, false);
+    }
+
+    /**
+     * The one immutable process-side configuration used by chains, tools, and
+     * commands. There is intentionally no reload or mutation method.
+     */
+    public static FollowConfig current() {
+        return CurrentHolder.INSTANCE;
+    }
+
+    public static Path defaultPath() {
+        return Services.PLATFORM.getConfigDir()
+                .resolve("numen")
+                .resolve(FILE_NAME);
+    }
+
+    /**
+     * Loads one path without changing startup-global state. Missing files are
+     * seeded with canonical defaults; invalid existing files are left intact.
+     */
+    public static FollowConfig load(Path path) {
+        Objects.requireNonNull(path, "path");
+        if (!Files.exists(path)) {
+            FollowConfig defaults = defaults();
+            try {
+                Path parent = path.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                Files.writeString(path, PRETTY.toJson(defaultJson()),
+                        StandardCharsets.UTF_8);
+            } catch (IOException | SecurityException exception) {
+                Constants.LOG.warn(
+                        "[owner-follow] could not create default configuration; "
+                                + "using in-memory defaults: {}",
+                        exception.getMessage());
+            }
+            return defaults;
+        }
+
+        try {
+            JsonElement root = JsonParser.parseString(
+                    Files.readString(path, StandardCharsets.UTF_8));
+            if (!root.isJsonObject()) {
+                throw new IllegalArgumentException("configuration root is not an object");
+            }
+            return parse(root.getAsJsonObject());
+        } catch (IOException | RuntimeException exception) {
+            Constants.LOG.warn(
+                    "[owner-follow] invalid configuration left unchanged; "
+                            + "using in-memory defaults: {}",
+                    exception.getMessage());
+            return defaults();
+        }
+    }
+
+    private static FollowConfig parse(JsonObject root) {
+        double stop = optionalDouble(root, STOP_DISTANCE, DEFAULT_STOP_DISTANCE);
+        double start = optionalDouble(root, START_DISTANCE, DEFAULT_START_DISTANCE);
+        double sprint = optionalDouble(root, SPRINT_DISTANCE, DEFAULT_SPRINT_DISTANCE);
+        double catchUp = optionalDouble(
+                root, CATCH_UP_DISTANCE, DEFAULT_CATCH_UP_DISTANCE);
+        double lost = optionalDouble(root, LOST_DISTANCE, DEFAULT_LOST_DISTANCE);
+        long cooldown = optionalCooldown(
+                root, FAILED_COOLDOWN_TICKS, DEFAULT_FAILED_COOLDOWN_TICKS);
+
+        boolean requestedUnsafeCapability = false;
+        requestedUnsafeCapability |= unsafeRequested(root, ALLOW_BREAK);
+        requestedUnsafeCapability |= unsafeRequested(root, ALLOW_PLACE);
+        requestedUnsafeCapability |= unsafeRequested(
+                root, ALLOW_WATER_BUCKET_LANDING);
+        requestedUnsafeCapability |= unsafeRequested(root, ALLOW_TELEPORT);
+        requestedUnsafeCapability |= unsafeRequested(root, ALLOW_CROSS_DIMENSION);
+        if (requestedUnsafeCapability) {
+            Constants.LOG.warn(
+                    "[owner-follow] unsafe capability flags were requested but "
+                            + "remain forcibly disabled");
+        }
+
+        if (!validNumericSet(stop, start, sprint, catchUp, lost, cooldown)) {
+            throw new IllegalArgumentException(
+                    "distance order must be stop < start < sprint <= catch_up < lost "
+                            + "and cooldown must be a positive bounded integer");
+        }
+        return new FollowConfig(stop, start, sprint, catchUp, lost, cooldown,
+                false, false, false, false, false);
+    }
+
+    private static double optionalDouble(
+            JsonObject root, String name, double defaultValue) {
+        JsonElement element = root.get(name);
+        if (element == null) {
+            return defaultValue;
+        }
+        if (!element.isJsonPrimitive()
+                || !element.getAsJsonPrimitive().isNumber()) {
+            throw new IllegalArgumentException(name + " must be a number");
+        }
+        double value = element.getAsDouble();
+        if (!Double.isFinite(value) || value <= 0.0) {
+            throw new IllegalArgumentException(
+                    name + " must be a finite positive number");
+        }
+        return value;
+    }
+
+    private static long optionalCooldown(
+            JsonObject root, String name, long defaultValue) {
+        JsonElement element = root.get(name);
+        if (element == null) {
+            return defaultValue;
+        }
+        if (!element.isJsonPrimitive()
+                || !element.getAsJsonPrimitive().isNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        String token = element.getAsString();
+        if (!INTEGER_TOKEN.matcher(token).matches()) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        BigInteger value = new BigInteger(token);
+        if (value.signum() <= 0 || value.compareTo(MAX_COOLDOWN) > 0) {
+            throw new IllegalArgumentException(
+                    name + " must be between 1 and " + Integer.MAX_VALUE);
+        }
+        return value.longValueExact();
+    }
+
+    private static boolean unsafeRequested(JsonObject root, String name) {
+        JsonElement element = root.get(name);
+        if (element == null) {
+            return false;
+        }
+        if (!element.isJsonPrimitive()
+                || !element.getAsJsonPrimitive().isBoolean()) {
+            throw new IllegalArgumentException(name + " must be a boolean");
+        }
+        return element.getAsBoolean();
+    }
+
+    private static boolean validNumericSet(
+            double stop,
+            double start,
+            double sprint,
+            double catchUp,
+            double lost,
+            long cooldown) {
+        return Double.isFinite(stop) && stop > 0.0
+                && Double.isFinite(start) && start > 0.0
+                && Double.isFinite(sprint) && sprint > 0.0
+                && Double.isFinite(catchUp) && catchUp > 0.0
+                && Double.isFinite(lost) && lost > 0.0
+                && stop < start
+                && start < sprint
+                && sprint <= catchUp
+                && catchUp < lost
+                && cooldown > 0L
+                && cooldown <= Integer.MAX_VALUE;
+    }
+
+    private static JsonObject defaultJson() {
+        JsonObject root = new JsonObject();
+        root.addProperty(STOP_DISTANCE, DEFAULT_STOP_DISTANCE);
+        root.addProperty(START_DISTANCE, DEFAULT_START_DISTANCE);
+        root.addProperty(SPRINT_DISTANCE, DEFAULT_SPRINT_DISTANCE);
+        root.addProperty(CATCH_UP_DISTANCE, DEFAULT_CATCH_UP_DISTANCE);
+        root.addProperty(LOST_DISTANCE, DEFAULT_LOST_DISTANCE);
+        root.addProperty(FAILED_COOLDOWN_TICKS, DEFAULT_FAILED_COOLDOWN_TICKS);
+        root.addProperty(ALLOW_BREAK, false);
+        root.addProperty(ALLOW_PLACE, false);
+        root.addProperty(ALLOW_WATER_BUCKET_LANDING, false);
+        root.addProperty(ALLOW_TELEPORT, false);
+        root.addProperty(ALLOW_CROSS_DIMENSION, false);
+        return root;
+    }
+
+    private static final class CurrentHolder {
+        private static final FollowConfig INSTANCE = load(defaultPath());
+
+        private CurrentHolder() {}
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowContextProvider.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowContextProvider.java
@@ -1,0 +1,44 @@
+package com.dwinovo.numen.core.follow;
+
+import com.dwinovo.numen.core.pathing.bridge.ContextFactory;
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.moves.CalculationContext;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
+import com.dwinovo.numen.entity.NumenPlayer;
+
+import it.unimi.dsi.fastutil.longs.LongSet;
+
+/**
+ * 自动跟随专用的无状态导航上下文提供器。搜索快照与执行期实时上下文
+ * 共用同一个 SAFE_FOLLOW builder，不修改全局导航设置。
+ */
+public final class FollowContextProvider implements PlayerNav.ContextProvider {
+
+    public static final FollowContextProvider INSTANCE = new FollowContextProvider();
+
+    private static final ContextFactory.ContextBuilder SAFE_CONTEXT =
+            (player, view, loadedTest, safeForThreadedUse, sacred, deniedPlace) ->
+                    new CalculationContext(player, view, loadedTest, safeForThreadedUse,
+                            sacred, deniedPlace, NavigationCapabilities.SAFE_FOLLOW);
+
+    private FollowContextProvider() {}
+
+    @Override
+    public CalculationContext forSearch(NumenPlayer player, LongSet sacred, LongSet deniedPlace) {
+        return ContextFactory.forSearch(player, sacred, deniedPlace, SAFE_CONTEXT);
+    }
+
+    @Override
+    public CalculationContext forExecution(NumenPlayer player, LongSet sacred,
+                                           LongSet deniedPlace) {
+        return ContextFactory.forExecution(player, sacred, deniedPlace, SAFE_CONTEXT);
+    }
+
+    static NavigationCapabilities capabilities() {
+        return NavigationCapabilities.SAFE_FOLLOW;
+    }
+
+    static ContextFactory.ContextBuilder contextBuilder() {
+        return SAFE_CONTEXT;
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowControlResult.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowControlResult.java
@@ -1,0 +1,22 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Objects;
+
+/**
+ * Immutable result envelope shared by the command and body-bound tool.
+ */
+public record FollowControlResult(
+        FollowAction action,
+        boolean success,
+        boolean changed,
+        String code,
+        String message,
+        FollowStatus status) {
+
+    public FollowControlResult {
+        Objects.requireNonNull(action, "action");
+        code = Objects.requireNonNull(code, "code");
+        message = Objects.requireNonNull(message, "message");
+        Objects.requireNonNull(status, "status");
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowDecisions.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowDecisions.java
@@ -11,19 +11,35 @@ import java.util.Objects;
 final class FollowDecisions {
 
     static final float PRIORITY = -2.0f;
-    static final double DEFAULT_STOP_DISTANCE = 3.0;
-    static final double DEFAULT_START_DISTANCE = 5.5;
-    static final double DEFAULT_SPRINT_DISTANCE = 12.0;
-    static final double DEFAULT_CATCH_UP_DISTANCE = 24.0;
-    static final double DEFAULT_LOST_DISTANCE = 64.0;
-    static final long FAILED_COOLDOWN_TICKS = 100L;
+    static final double DEFAULT_STOP_DISTANCE =
+            FollowConfig.DEFAULT_STOP_DISTANCE;
+    static final double DEFAULT_START_DISTANCE =
+            FollowConfig.DEFAULT_START_DISTANCE;
+    static final double DEFAULT_SPRINT_DISTANCE =
+            FollowConfig.DEFAULT_SPRINT_DISTANCE;
+    static final double DEFAULT_CATCH_UP_DISTANCE =
+            FollowConfig.DEFAULT_CATCH_UP_DISTANCE;
+    static final double DEFAULT_LOST_DISTANCE =
+            FollowConfig.DEFAULT_LOST_DISTANCE;
+    static final long FAILED_COOLDOWN_TICKS =
+            FollowConfig.DEFAULT_FAILED_COOLDOWN_TICKS;
     static final long NO_FAILED_COOLDOWN = Long.MIN_VALUE;
 
     private FollowDecisions() {}
 
     static Result decide(Input input, boolean wasFollowing, long failedUntilTick) {
+        return decide(input, wasFollowing, failedUntilTick, FollowConfig.defaults());
+    }
+
+    static Result decide(
+            Input input,
+            boolean wasFollowing,
+            long failedUntilTick,
+            FollowConfig config) {
         Objects.requireNonNull(input, "input");
-        Distances distances = resolveDistances(input.stopOverride(), input.startOverride());
+        Objects.requireNonNull(config, "config");
+        Distances distances = resolveDistances(
+                input.stopOverride(), input.startOverride(), config);
 
         if (!input.companionValid()) {
             return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
@@ -57,7 +73,7 @@ final class FollowDecisions {
             return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
                     FollowWaitingReason.OWNER_INVALID, false, distances);
         }
-        if (input.distance() >= DEFAULT_LOST_DISTANCE) {
+        if (input.distance() >= config.lostDistance()) {
             return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
                     FollowWaitingReason.OWNER_TOO_FAR, wasFollowing, distances);
         }
@@ -79,17 +95,23 @@ final class FollowDecisions {
         }
         return new Result(FollowRuntimeState.FOLLOWING, FollowWaitingReason.NONE,
                 PRIORITY, true,
-                input.distance() >= DEFAULT_SPRINT_DISTANCE,
-                input.distance() >= DEFAULT_CATCH_UP_DISTANCE,
+                input.distance() >= config.sprintDistance(),
+                input.distance() >= config.catchUpDistance(),
                 NO_FAILED_COOLDOWN, distances);
     }
 
     static Result failedAt(Result previous, long currentTick) {
+        return failedAt(previous, currentTick, FollowConfig.defaults());
+    }
+
+    static Result failedAt(
+            Result previous, long currentTick, FollowConfig config) {
         Objects.requireNonNull(previous, "previous");
+        Objects.requireNonNull(config, "config");
         return new Result(FollowRuntimeState.FAILED_COOLDOWN,
                 FollowWaitingReason.NONE, Float.NEGATIVE_INFINITY,
                 previous.following(), false, false,
-                currentTick + FAILED_COOLDOWN_TICKS, previous.distances());
+                currentTick + config.failedCooldownTicks(), previous.distances());
     }
 
     static long remainingCooldownTicks(long failedUntilTick, long currentTick) {
@@ -100,12 +122,21 @@ final class FollowDecisions {
     }
 
     static Distances resolveDistances(Double stopOverride, Double startOverride) {
+        return resolveDistances(
+                stopOverride, startOverride, FollowConfig.defaults());
+    }
+
+    static Distances resolveDistances(
+            Double stopOverride,
+            Double startOverride,
+            FollowConfig config) {
+        Objects.requireNonNull(config, "config");
         if (stopOverride == null || startOverride == null
                 || !Double.isFinite(stopOverride) || !Double.isFinite(startOverride)
                 || stopOverride <= 0.0 || startOverride <= 0.0
                 || stopOverride >= startOverride
-                || startOverride >= DEFAULT_SPRINT_DISTANCE) {
-            return new Distances(DEFAULT_STOP_DISTANCE, DEFAULT_START_DISTANCE);
+                || startOverride >= config.sprintDistance()) {
+            return new Distances(config.stopDistance(), config.startDistance());
         }
         return new Distances(stopOverride, startOverride);
     }

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowDecisions.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowDecisions.java
@@ -1,0 +1,162 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Objects;
+
+/**
+ * Pure owner-follow state machine.
+ *
+ * <p>The inputs and outputs contain no Minecraft objects, perform no I/O, and
+ * retain no mutable global state.
+ */
+final class FollowDecisions {
+
+    static final float PRIORITY = -2.0f;
+    static final double DEFAULT_STOP_DISTANCE = 3.0;
+    static final double DEFAULT_START_DISTANCE = 5.5;
+    static final double DEFAULT_SPRINT_DISTANCE = 12.0;
+    static final double DEFAULT_CATCH_UP_DISTANCE = 24.0;
+    static final double DEFAULT_LOST_DISTANCE = 64.0;
+    static final long FAILED_COOLDOWN_TICKS = 100L;
+    static final long NO_FAILED_COOLDOWN = Long.MIN_VALUE;
+
+    private FollowDecisions() {}
+
+    static Result decide(Input input, boolean wasFollowing, long failedUntilTick) {
+        Objects.requireNonNull(input, "input");
+        Distances distances = resolveDistances(input.stopOverride(), input.startOverride());
+
+        if (!input.companionValid()) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.COMPANION_NOT_ACTIVE, false, distances);
+        }
+        if (!input.enabled()) {
+            return dormant(FollowRuntimeState.DISABLED,
+                    FollowWaitingReason.NONE, false, distances);
+        }
+        if (input.manualPaused()) {
+            return dormant(FollowRuntimeState.MANUALLY_PAUSED,
+                    FollowWaitingReason.NONE, false, distances);
+        }
+        if (!input.ownerUuidPresent()) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.OWNER_INVALID, false, distances);
+        }
+        if (!input.ownerOnline()) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.OWNER_OFFLINE, false, distances);
+        }
+        if (!input.ownerValid()) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.OWNER_INVALID, false, distances);
+        }
+        if (!input.sameLevel()) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.OWNER_OTHER_DIMENSION, false, distances);
+        }
+        if (!Double.isFinite(input.distance())) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.OWNER_INVALID, false, distances);
+        }
+        if (input.distance() >= DEFAULT_LOST_DISTANCE) {
+            return dormant(FollowRuntimeState.WAITING_FOR_OWNER,
+                    FollowWaitingReason.OWNER_TOO_FAR, wasFollowing, distances);
+        }
+        if (input.distance() <= distances.stop()) {
+            return dormant(FollowRuntimeState.IDLE_NEAR_OWNER,
+                    FollowWaitingReason.NONE, false, distances);
+        }
+        if (input.currentTick() < failedUntilTick) {
+            return new Result(FollowRuntimeState.FAILED_COOLDOWN,
+                    FollowWaitingReason.NONE, Float.NEGATIVE_INFINITY,
+                    wasFollowing, false, false, failedUntilTick, distances);
+        }
+
+        boolean following = input.distance() >= distances.start()
+                || wasFollowing && input.distance() > distances.stop();
+        if (!following) {
+            return dormant(FollowRuntimeState.IDLE_NEAR_OWNER,
+                    FollowWaitingReason.NONE, false, distances);
+        }
+        return new Result(FollowRuntimeState.FOLLOWING, FollowWaitingReason.NONE,
+                PRIORITY, true,
+                input.distance() >= DEFAULT_SPRINT_DISTANCE,
+                input.distance() >= DEFAULT_CATCH_UP_DISTANCE,
+                NO_FAILED_COOLDOWN, distances);
+    }
+
+    static Result failedAt(Result previous, long currentTick) {
+        Objects.requireNonNull(previous, "previous");
+        return new Result(FollowRuntimeState.FAILED_COOLDOWN,
+                FollowWaitingReason.NONE, Float.NEGATIVE_INFINITY,
+                previous.following(), false, false,
+                currentTick + FAILED_COOLDOWN_TICKS, previous.distances());
+    }
+
+    static long remainingCooldownTicks(long failedUntilTick, long currentTick) {
+        if (failedUntilTick == NO_FAILED_COOLDOWN || currentTick >= failedUntilTick) {
+            return 0L;
+        }
+        return failedUntilTick - currentTick;
+    }
+
+    static Distances resolveDistances(Double stopOverride, Double startOverride) {
+        if (stopOverride == null || startOverride == null
+                || !Double.isFinite(stopOverride) || !Double.isFinite(startOverride)
+                || stopOverride <= 0.0 || startOverride <= 0.0
+                || stopOverride >= startOverride
+                || startOverride >= DEFAULT_SPRINT_DISTANCE) {
+            return new Distances(DEFAULT_STOP_DISTANCE, DEFAULT_START_DISTANCE);
+        }
+        return new Distances(stopOverride, startOverride);
+    }
+
+    static double distance3d(double firstX, double firstY, double firstZ,
+                             double secondX, double secondY, double secondZ) {
+        double dx = secondX - firstX;
+        double dy = secondY - firstY;
+        double dz = secondZ - firstZ;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    private static Result dormant(FollowRuntimeState state, FollowWaitingReason reason,
+                                   boolean following, Distances distances) {
+        return new Result(state, reason, Float.NEGATIVE_INFINITY, following,
+                false, false, NO_FAILED_COOLDOWN, distances);
+    }
+
+    record Input(
+            boolean enabled,
+            boolean manualPaused,
+            boolean companionValid,
+            boolean ownerUuidPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameLevel,
+            double distance,
+            Double stopOverride,
+            Double startOverride,
+            long currentTick) {}
+
+    record Distances(double stop, double start) {}
+
+    record Result(
+            FollowRuntimeState runtimeState,
+            FollowWaitingReason waitingReason,
+            float priority,
+            boolean following,
+            boolean sprintAllowed,
+            boolean catchingUp,
+            long failedUntilTick,
+            Distances distances) {
+
+        Result {
+            Objects.requireNonNull(runtimeState, "runtimeState");
+            Objects.requireNonNull(waitingReason, "waitingReason");
+            Objects.requireNonNull(distances, "distances");
+        }
+
+        boolean active() {
+            return priority == PRIORITY;
+        }
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowOwnerTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowOwnerTool.java
@@ -1,0 +1,143 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import com.dwinovo.numen.agent.tool.NumenTool;
+import com.dwinovo.numen.agent.tool.Schema;
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.dwinovo.numen.task.TaskResult;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Body-bound LLM control for the current companion's owner-follow intent.
+ */
+public final class FollowOwnerTool implements NumenTool {
+
+    public static final String TOOL_NAME = "follow_owner";
+
+    private static final Set<String> ARGUMENTS = Set.of("action");
+
+    private final FollowConfig config;
+    private final ControlInvoker controlInvoker;
+
+    public FollowOwnerTool(FollowConfig config) {
+        this(config, FollowService::apply);
+    }
+
+    FollowOwnerTool(FollowConfig config, ControlInvoker controlInvoker) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.controlInvoker =
+                Objects.requireNonNull(controlInvoker, "controlInvoker");
+    }
+
+    @Override
+    public String name() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public String description() {
+        return """
+                Control or inspect automatic owner-follow for this current companion body only.
+                Call only when the user explicitly asks to control or query automatic following:
+                “跟着我”/“开始跟随” = on; “以后别跟了”/“关闭自动跟随” = off;
+                “先在这里等一下”/“暂时别跟” = pause; “继续跟我” = resume;
+                “你为什么不动”/“跟随状态” = status.
+                on/off/pause/resume must be performed with this tool; never merely claim the state changed.
+                Do NOT use for ordinary goto or coordinate movement: “去某坐标” remains goto.
+                Use resume for a vague “继续” only when context clearly means a paused follow.
+                This tool changes state only. OwnerFollowChain performs movement in the background;
+                it does not teleport the companion or move it immediately.""";
+    }
+
+    @Override
+    public Map<String, Object> parameterSchema() {
+        return Schema.object()
+                .enumStr("action",
+                        "Automatic-follow control: on, off, pause, resume, or status.",
+                        "on", "off", "pause", "resume", "status")
+                .build();
+    }
+
+    @Override
+    public void onServerCall(
+            String toolCallId,
+            JsonObject args,
+            NumenPlayer companion,
+            Consumer<String> reply) {
+        Objects.requireNonNull(reply, "reply");
+        if (companion == null || companion.getOwnerUuid() == null) {
+            reply.accept(TaskResult.fail(
+                    "当前同伴没有可验证的主人绑定，无法控制自动跟随。").toJson());
+            return;
+        }
+        MinecraftServer server = companion.level().getServer();
+        if (server == null) {
+            reply.accept(TaskResult.fail(
+                    "当前同伴不在可用的服务器世界中。").toJson());
+            return;
+        }
+
+        FollowAction action;
+        try {
+            action = parseArguments(args);
+        } catch (IllegalArgumentException exception) {
+            reply.accept(TaskResult.fail(exception.getMessage()).toJson());
+            return;
+        }
+
+        FollowControlResult result =
+                invokeControl(server, companion, action);
+        reply.accept(resultJson(result));
+    }
+
+    static String resultJson(FollowControlResult result) {
+        Map<String, Object> data = Map.of(
+                "code", result.code(),
+                "changed", result.changed(),
+                "status", result.status().compactText());
+        TaskResult taskResult = result.success()
+                ? TaskResult.ok(result.message(), data)
+                : TaskResult.fail(result.message(), data);
+        return taskResult.toJson();
+    }
+
+    FollowControlResult invokeControl(
+            MinecraftServer server,
+            NumenPlayer companion,
+            FollowAction action) {
+        return controlInvoker.apply(server, companion, action, config);
+    }
+
+    static FollowAction parseArguments(JsonObject args) {
+        if (args == null || !args.keySet().equals(ARGUMENTS)) {
+            throw new IllegalArgumentException(
+                    "follow_owner 只接受 action 参数。");
+        }
+        JsonElement element = args.get("action");
+        if (element == null
+                || !element.isJsonPrimitive()
+                || !element.getAsJsonPrimitive().isString()) {
+            throw new IllegalArgumentException(
+                    "action 必须是 on、off、pause、resume 或 status。");
+        }
+        return FollowAction.parse(element.getAsString())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "未知 action；只能使用 on、off、pause、resume 或 status。"));
+    }
+
+    @FunctionalInterface
+    interface ControlInvoker {
+        FollowControlResult apply(
+                MinecraftServer server,
+                NumenPlayer companion,
+                FollowAction action,
+                FollowConfig config);
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowReleaseReason.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowReleaseReason.java
@@ -1,0 +1,15 @@
+package com.dwinovo.numen.core.follow;
+
+/**
+ * Why transient owner-follow control is being relinquished.
+ */
+public enum FollowReleaseReason {
+    SCHEDULER_INTERRUPT,
+    FOLLOW_DISABLED,
+    MANUAL_PAUSE,
+    COMPANION_DEATH,
+    COMPANION_REMOVED,
+    SERVER_STOPPING,
+    RUNTIME_REPLACED,
+    INTERNAL_STATE_CHANGE
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowRuntimeControl.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowRuntimeControl.java
@@ -1,0 +1,15 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.UUID;
+
+/**
+ * Transient control surface for one live companion follow runtime.
+ */
+public interface FollowRuntimeControl {
+
+    UUID companionUuid();
+
+    void release(FollowReleaseReason reason);
+
+    FollowRuntimeSnapshot snapshot(long currentGameTime);
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowRuntimeSnapshot.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowRuntimeSnapshot.java
@@ -1,0 +1,23 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Objects;
+
+/**
+ * Immutable, Minecraft-object-free view of one companion's follow runtime.
+ */
+public record FollowRuntimeSnapshot(
+        FollowRuntimeState runtimeState,
+        FollowWaitingReason waitingReason,
+        boolean following,
+        boolean navigationActive,
+        boolean sprintAllowed,
+        boolean catchingUp,
+        long failedUntilTick,
+        long remainingCooldownTicks) {
+
+    public FollowRuntimeSnapshot {
+        Objects.requireNonNull(runtimeState, "runtimeState");
+        Objects.requireNonNull(waitingReason, "waitingReason");
+        remainingCooldownTicks = Math.max(0L, remainingCooldownTicks);
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowRuntimeState.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowRuntimeState.java
@@ -1,0 +1,16 @@
+package com.dwinovo.numen.core.follow;
+
+/**
+ * Transient, per-companion owner-follow execution state.
+ *
+ * <p>This state is intentionally not part of {@link FollowState} and is never
+ * written to saved data.
+ */
+public enum FollowRuntimeState {
+    DISABLED,
+    MANUALLY_PAUSED,
+    WAITING_FOR_OWNER,
+    IDLE_NEAR_OWNER,
+    FOLLOWING,
+    FAILED_COOLDOWN
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowService.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowService.java
@@ -1,0 +1,65 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Runtime-only facade for lifecycle and status integrations.
+ *
+ * <p>Persistent follow intent remains the responsibility of
+ * {@link FollowStateStore}; this facade cannot enable, disable, pause, or
+ * otherwise mutate that intent.
+ */
+public final class FollowService {
+
+    private FollowService() {}
+
+    public static void releaseRuntime(
+            MinecraftServer server, UUID companionUuid, FollowReleaseReason reason) {
+        MinecraftServer checkedServer = requireServer(server);
+        UUID checkedUuid = requireUuid(companionUuid);
+        FollowReleaseReason checkedReason = requireReason(reason);
+        FollowStateStore.get(checkedServer)
+                .releaseRuntime(checkedUuid, checkedReason);
+    }
+
+    public static void removeRuntime(
+            MinecraftServer server, UUID companionUuid, FollowReleaseReason reason) {
+        MinecraftServer checkedServer = requireServer(server);
+        UUID checkedUuid = requireUuid(companionUuid);
+        FollowReleaseReason checkedReason = requireReason(reason);
+        FollowStateStore.get(checkedServer)
+                .removeRuntime(checkedUuid, checkedReason);
+    }
+
+    public static int releaseAllRuntime(
+            MinecraftServer server, FollowReleaseReason reason) {
+        MinecraftServer checkedServer = requireServer(server);
+        FollowReleaseReason checkedReason = requireReason(reason);
+        return FollowStateStore.get(checkedServer)
+                .releaseAllRuntime(checkedReason);
+    }
+
+    public static Optional<FollowRuntimeSnapshot> runtimeSnapshot(
+            MinecraftServer server, UUID companionUuid, long currentGameTime) {
+        MinecraftServer checkedServer = requireServer(server);
+        UUID checkedUuid = requireUuid(companionUuid);
+        return FollowStateStore.get(checkedServer)
+                .runtimeSnapshot(checkedUuid, currentGameTime);
+    }
+
+    private static MinecraftServer requireServer(MinecraftServer server) {
+        return Objects.requireNonNull(server, "server");
+    }
+
+    private static UUID requireUuid(UUID companionUuid) {
+        return Objects.requireNonNull(companionUuid, "companionUuid");
+    }
+
+    private static FollowReleaseReason requireReason(FollowReleaseReason reason) {
+        return Objects.requireNonNull(reason, "reason");
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowService.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowService.java
@@ -31,12 +31,18 @@ public final class FollowService {
     }
 
     public static void removeRuntime(
-            MinecraftServer server, UUID companionUuid, FollowReleaseReason reason) {
+            MinecraftServer server,
+            NumenPlayer companion,
+            FollowReleaseReason reason) {
         MinecraftServer checkedServer = requireServer(server);
-        UUID checkedUuid = requireUuid(companionUuid);
+        NumenPlayer checkedCompanion =
+                Objects.requireNonNull(companion, "companion");
         FollowReleaseReason checkedReason = requireReason(reason);
         FollowStateStore.get(checkedServer)
-                .removeRuntime(checkedUuid, checkedReason);
+                .removeRuntime(
+                        checkedCompanion.getUUID(),
+                        checkedCompanion,
+                        checkedReason);
     }
 
     public static int releaseAllRuntime(

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowService.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowService.java
@@ -2,9 +2,13 @@ package com.dwinovo.numen.core.follow;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.UUID;
 
+import com.dwinovo.numen.entity.NumenPlayer;
+
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
 
 /**
  * Runtime-only facade for lifecycle and status integrations.
@@ -17,12 +21,12 @@ public final class FollowService {
 
     private FollowService() {}
 
-    public static void releaseRuntime(
+    public static boolean releaseRuntime(
             MinecraftServer server, UUID companionUuid, FollowReleaseReason reason) {
         MinecraftServer checkedServer = requireServer(server);
         UUID checkedUuid = requireUuid(companionUuid);
         FollowReleaseReason checkedReason = requireReason(reason);
-        FollowStateStore.get(checkedServer)
+        return FollowStateStore.get(checkedServer)
                 .releaseRuntime(checkedUuid, checkedReason);
     }
 
@@ -49,6 +53,273 @@ public final class FollowService {
         UUID checkedUuid = requireUuid(companionUuid);
         return FollowStateStore.get(checkedServer)
                 .runtimeSnapshot(checkedUuid, currentGameTime);
+    }
+
+    /**
+     * Applies one user control to the current body. The tool and command both
+     * enter through this method; navigation remains scheduler-owned.
+     */
+    public static FollowControlResult apply(
+            MinecraftServer server,
+            NumenPlayer companion,
+            FollowAction action,
+            FollowConfig config) {
+        MinecraftServer checkedServer = requireServer(server);
+        NumenPlayer checkedCompanion =
+                Objects.requireNonNull(companion, "companion");
+        FollowAction checkedAction = Objects.requireNonNull(action, "action");
+        FollowConfig checkedConfig = Objects.requireNonNull(config, "config");
+        return apply(
+                FollowStateStore.get(checkedServer),
+                subject(checkedCompanion),
+                checkedAction,
+                checkedConfig);
+    }
+
+    public static FollowStatus status(
+            MinecraftServer server,
+            NumenPlayer companion,
+            FollowConfig config) {
+        MinecraftServer checkedServer = requireServer(server);
+        NumenPlayer checkedCompanion =
+                Objects.requireNonNull(companion, "companion");
+        FollowConfig checkedConfig = Objects.requireNonNull(config, "config");
+        return status(
+                FollowStateStore.get(checkedServer),
+                subject(checkedCompanion),
+                checkedConfig);
+    }
+
+    static FollowControlResult apply(
+            FollowStateStore store,
+            Subject subject,
+            FollowAction action,
+            FollowConfig config) {
+        Objects.requireNonNull(store, "store");
+        Objects.requireNonNull(subject, "subject");
+        Objects.requireNonNull(action, "action");
+        Objects.requireNonNull(config, "config");
+
+        FollowState before = store.getOrDefault(subject.companionUuid());
+        if (action == FollowAction.STATUS) {
+            FollowStatus status = status(store, subject, config);
+            return result(action, true, false, "STATUS",
+                    status.compactText(), status);
+        }
+        if (!subject.companionValid() || !subject.ownerPresent()) {
+            FollowStatus status = status(store, subject, config);
+            return result(action, false, false, "INVALID_COMPANION",
+                    "当前同伴或主人绑定不可用于自动跟随控制。", status);
+        }
+
+        return switch (action) {
+            case ON -> {
+                boolean changed = store.setControlState(
+                        subject.companionUuid(), true, false);
+                FollowStatus status = status(store, subject, config);
+                yield result(action, true, changed,
+                        changed ? "ENABLED" : "ALREADY_ENABLED",
+                        changed
+                                ? "已开启自动跟随；移动将在后台调度器下次评估时开始。"
+                                : "自动跟随已经开启。",
+                        status);
+            }
+            case OFF -> {
+                boolean changed = store.setControlState(
+                        subject.companionUuid(), false, false);
+                boolean released = store.releaseRuntime(
+                        subject.companionUuid(), FollowReleaseReason.FOLLOW_DISABLED);
+                FollowStatus status = status(store, subject, config);
+                yield released
+                        ? result(action, true, changed,
+                                changed ? "DISABLED" : "ALREADY_DISABLED",
+                                changed
+                                        ? "已关闭自动跟随并释放当前移动控制。"
+                                        : "自动跟随已经关闭；已再次清理运行控制。",
+                                status)
+                        : releaseWarning(action, changed, status);
+            }
+            case PAUSE -> {
+                if (!before.enabled()) {
+                    FollowStatus status = status(store, subject, config);
+                    yield result(action, false, false,
+                            "PAUSE_REQUIRES_ENABLED",
+                            "自动跟随当前已关闭；请使用 on 或 resume 启用。",
+                            status);
+                }
+                boolean changed = store.setControlState(
+                        subject.companionUuid(), true, true);
+                boolean released = store.releaseRuntime(
+                        subject.companionUuid(), FollowReleaseReason.MANUAL_PAUSE);
+                FollowStatus status = status(store, subject, config);
+                yield released
+                        ? result(action, true, changed,
+                                changed ? "PAUSED" : "ALREADY_PAUSED",
+                                changed
+                                        ? "已暂停自动跟随并释放当前移动控制。"
+                                        : "自动跟随已经暂停；已再次清理运行控制。",
+                                status)
+                        : releaseWarning(action, changed, status);
+            }
+            case RESUME -> {
+                boolean changed = store.setControlState(
+                        subject.companionUuid(), true, false);
+                FollowStatus status = status(store, subject, config);
+                yield result(action, true, changed,
+                        changed ? "RESUMED" : "ALREADY_RESUMED",
+                        changed
+                                ? "已恢复自动跟随；移动将在后台调度器下次评估时继续。"
+                                : "自动跟随已经处于可运行状态。",
+                        status);
+            }
+            case STATUS -> throw new IllegalStateException(
+                    "status handled before mutable controls");
+        };
+    }
+
+    static FollowStatus status(
+            FollowStateStore store, Subject subject, FollowConfig config) {
+        Objects.requireNonNull(store, "store");
+        Objects.requireNonNull(subject, "subject");
+        Objects.requireNonNull(config, "config");
+
+        FollowState state = store.getOrDefault(subject.companionUuid());
+        FollowDecisions.Distances distances = FollowDecisions.resolveDistances(
+                state.stopDistanceOverride(), state.startDistanceOverride(), config);
+        Optional<FollowRuntimeSnapshot> runtime =
+                store.runtimeSnapshot(subject.companionUuid(), subject.gameTime());
+
+        FollowRuntimeSnapshot snapshot = runtime.orElseGet(
+                () -> conservativeSnapshot(state, subject, config));
+        return new FollowStatus(
+                subject.companionUuid(),
+                subject.companionName(),
+                state.enabled(),
+                state.manualPaused(),
+                runtime.isPresent(),
+                snapshot.runtimeState(),
+                snapshot.waitingReason(),
+                snapshot.following(),
+                snapshot.navigationActive(),
+                snapshot.sprintAllowed(),
+                snapshot.catchingUp(),
+                snapshot.remainingCooldownTicks(),
+                subject.ownerPresent(),
+                subject.ownerOnline(),
+                subject.sameDimension(),
+                subject.distance(),
+                distances.stop(),
+                distances.start(),
+                config.sprintDistance(),
+                config.catchUpDistance(),
+                config.lostDistance(),
+                config.failedCooldownTicks());
+    }
+
+    private static FollowRuntimeSnapshot conservativeSnapshot(
+            FollowState state, Subject subject, FollowConfig config) {
+        FollowRuntimeState runtimeState;
+        FollowWaitingReason waitingReason;
+        if (!state.enabled()) {
+            runtimeState = FollowRuntimeState.DISABLED;
+            waitingReason = FollowWaitingReason.NONE;
+        } else if (state.manualPaused()) {
+            runtimeState = FollowRuntimeState.MANUALLY_PAUSED;
+            waitingReason = FollowWaitingReason.NONE;
+        } else if (!subject.companionValid()) {
+            runtimeState = FollowRuntimeState.WAITING_FOR_OWNER;
+            waitingReason = FollowWaitingReason.COMPANION_NOT_ACTIVE;
+        } else if (!subject.ownerPresent() || !subject.ownerValid()) {
+            runtimeState = FollowRuntimeState.WAITING_FOR_OWNER;
+            waitingReason = subject.ownerPresent() && !subject.ownerOnline()
+                    ? FollowWaitingReason.OWNER_OFFLINE
+                    : FollowWaitingReason.OWNER_INVALID;
+        } else if (!subject.sameDimension()) {
+            runtimeState = FollowRuntimeState.WAITING_FOR_OWNER;
+            waitingReason = FollowWaitingReason.OWNER_OTHER_DIMENSION;
+        } else if (subject.distance().isPresent()
+                && subject.distance().getAsDouble() >= config.lostDistance()) {
+            runtimeState = FollowRuntimeState.WAITING_FOR_OWNER;
+            waitingReason = FollowWaitingReason.OWNER_TOO_FAR;
+        } else {
+            runtimeState = FollowRuntimeState.WAITING_FOR_OWNER;
+            waitingReason = FollowWaitingReason.OWNER_INVALID;
+        }
+        return new FollowRuntimeSnapshot(
+                runtimeState,
+                waitingReason,
+                false,
+                false,
+                false,
+                false,
+                FollowDecisions.NO_FAILED_COOLDOWN,
+                0L);
+    }
+
+    private static Subject subject(NumenPlayer companion) {
+        boolean companionValid = !companion.isRemoved() && companion.isAlive();
+        boolean ownerPresent = companion.getOwnerUuid() != null;
+        ServerPlayer owner = ownerPresent ? companion.resolveOwnerPlayer() : null;
+        boolean ownerOnline = owner != null;
+        boolean ownerValid =
+                ownerOnline && !owner.isRemoved() && owner.isAlive();
+        boolean sameDimension =
+                ownerValid && owner.level() == companion.level();
+        OptionalDouble distance = sameDimension
+                ? OptionalDouble.of(FollowDecisions.distance3d(
+                        companion.getX(), companion.getY(), companion.getZ(),
+                        owner.getX(), owner.getY(), owner.getZ()))
+                : OptionalDouble.empty();
+        return new Subject(
+                companion.getUUID(),
+                companion.getName().getString(),
+                companionValid,
+                ownerPresent,
+                ownerOnline,
+                ownerValid,
+                sameDimension,
+                distance,
+                companion.level().getGameTime());
+    }
+
+    private static FollowControlResult releaseWarning(
+            FollowAction action, boolean changed, FollowStatus status) {
+        return result(
+                action,
+                true,
+                changed,
+                "RUNTIME_RELEASE_WARNING",
+                "跟随意图已保存，但运行控制未能确认完全释放；请检查服务器日志。",
+                status);
+    }
+
+    private static FollowControlResult result(
+            FollowAction action,
+            boolean success,
+            boolean changed,
+            String code,
+            String message,
+            FollowStatus status) {
+        return new FollowControlResult(
+                action, success, changed, code, message, status);
+    }
+
+    record Subject(
+            UUID companionUuid,
+            String companionName,
+            boolean companionValid,
+            boolean ownerPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameDimension,
+            OptionalDouble distance,
+            long gameTime) {
+
+        Subject {
+            Objects.requireNonNull(companionUuid, "companionUuid");
+            companionName = Objects.requireNonNullElse(companionName, "");
+            distance = Objects.requireNonNull(distance, "distance");
+        }
     }
 
     private static MinecraftServer requireServer(MinecraftServer server) {

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowState.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowState.java
@@ -1,0 +1,56 @@
+package com.dwinovo.numen.core.follow;
+
+/**
+ * The persisted follow intent for one companion.
+ *
+ * <p>This record deliberately contains no owner identity or runtime navigation
+ * state. The companion UUID is the key in {@link FollowStateStore}; the owner
+ * remains authoritative in Numen's existing player data and registry.
+ */
+public record FollowState(
+        boolean enabled,
+        boolean manualPaused,
+        int schemaVersion,
+        Double stopDistanceOverride,
+        Double startDistanceOverride) {
+
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+
+    public FollowState {
+        if (schemaVersion != CURRENT_SCHEMA_VERSION) {
+            throw new IllegalArgumentException("unsupported follow state schema " + schemaVersion);
+        }
+        validateDistance("stopDistanceOverride", stopDistanceOverride);
+        validateDistance("startDistanceOverride", startDistanceOverride);
+        if (stopDistanceOverride != null && startDistanceOverride != null
+                && stopDistanceOverride >= startDistanceOverride) {
+            throw new IllegalArgumentException("stop distance must be less than start distance");
+        }
+    }
+
+    /** Safe intent for a companion with no saved follow entry. */
+    public static FollowState defaults() {
+        return new FollowState(false, false, CURRENT_SCHEMA_VERSION, null, null);
+    }
+
+    public FollowState withEnabled(boolean value) {
+        return new FollowState(value, manualPaused, schemaVersion,
+                stopDistanceOverride, startDistanceOverride);
+    }
+
+    public FollowState withManualPaused(boolean value) {
+        return new FollowState(enabled, value, schemaVersion,
+                stopDistanceOverride, startDistanceOverride);
+    }
+
+    public FollowState withDistanceOverrides(Double stopDistance, Double startDistance) {
+        return new FollowState(enabled, manualPaused, schemaVersion,
+                stopDistance, startDistance);
+    }
+
+    private static void validateDistance(String name, Double value) {
+        if (value != null && (!Double.isFinite(value) || value <= 0.0)) {
+            throw new IllegalArgumentException(name + " must be a finite positive number");
+        }
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
@@ -1,0 +1,190 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.saveddata.SavedData;
+
+/**
+ * Independent world-saved follow intent, keyed only by companion UUID.
+ *
+ * <p>The file intentionally does not extend the companion registry or player
+ * NBT. Removing a modified Numen JAR therefore leaves an unreferenced SavedData
+ * file that the original mod can safely ignore.
+ */
+public final class FollowStateStore extends SavedData {
+
+    public static final String DATA_NAME = "numen_auto_follow";
+
+    private static final String KEY_ENTRIES = "entries";
+    private static final String KEY_COMPANION_UUID = "companionUuid";
+    private static final String KEY_ENABLED = "enabled";
+    private static final String KEY_MANUAL_PAUSED = "manualPaused";
+    private static final String KEY_SCHEMA_VERSION = "schemaVersion";
+    private static final String KEY_STOP_DISTANCE = "stopDistanceOverride";
+    private static final String KEY_START_DISTANCE = "startDistanceOverride";
+
+    private final Map<UUID, FollowState> states;
+
+    FollowStateStore() {
+        this.states = new HashMap<>();
+    }
+
+    private FollowStateStore(Map<UUID, FollowState> states) {
+        this.states = new HashMap<>(states);
+    }
+
+    public static FollowStateStore get(MinecraftServer server) {
+        return server.overworld().getDataStorage()
+                .computeIfAbsent(FollowStateStore::load, FollowStateStore::new, DATA_NAME);
+    }
+
+    static FollowStateStore load(CompoundTag root) {
+        if (root == null || !root.contains(KEY_ENTRIES, Tag.TAG_LIST)) {
+            return new FollowStateStore();
+        }
+
+        Map<UUID, FollowState> loaded = new HashMap<>();
+        try {
+            ListTag entries = root.getList(KEY_ENTRIES, Tag.TAG_COMPOUND);
+            for (Tag element : entries) {
+                if (!(element instanceof CompoundTag entry)) {
+                    continue;
+                }
+                try {
+                    readEntry(entry).ifPresent(state ->
+                            loaded.put(entry.getUUID(KEY_COMPANION_UUID), state));
+                } catch (RuntimeException ignored) {
+                    // A malformed companion entry is isolated from every other entry.
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // A malformed top-level payload is equivalent to no follow state.
+            return new FollowStateStore();
+        }
+        return new FollowStateStore(loaded);
+    }
+
+    private static Optional<FollowState> readEntry(CompoundTag entry) {
+        if (!entry.hasUUID(KEY_COMPANION_UUID)) {
+            return Optional.empty();
+        }
+
+        boolean enabled = readOptionalBoolean(entry, KEY_ENABLED, false);
+        boolean manualPaused = readOptionalBoolean(entry, KEY_MANUAL_PAUSED, false);
+        int schemaVersion = readOptionalInt(entry, KEY_SCHEMA_VERSION,
+                FollowState.CURRENT_SCHEMA_VERSION);
+        Double stopDistance = readOptionalDistance(entry, KEY_STOP_DISTANCE);
+        Double startDistance = readOptionalDistance(entry, KEY_START_DISTANCE);
+
+        return Optional.of(new FollowState(enabled, manualPaused, schemaVersion,
+                stopDistance, startDistance));
+    }
+
+    private static boolean readOptionalBoolean(CompoundTag entry, String key, boolean defaultValue) {
+        if (!entry.contains(key)) {
+            return defaultValue;
+        }
+        requireNumeric(entry, key);
+        return entry.getBoolean(key);
+    }
+
+    private static int readOptionalInt(CompoundTag entry, String key, int defaultValue) {
+        if (!entry.contains(key)) {
+            return defaultValue;
+        }
+        requireNumeric(entry, key);
+        return entry.getInt(key);
+    }
+
+    private static Double readOptionalDistance(CompoundTag entry, String key) {
+        if (!entry.contains(key)) {
+            return null;
+        }
+        requireNumeric(entry, key);
+        return entry.getDouble(key);
+    }
+
+    private static void requireNumeric(CompoundTag entry, String key) {
+        if (!entry.contains(key, Tag.TAG_ANY_NUMERIC)) {
+            throw new IllegalArgumentException("follow state field '" + key + "' is not numeric");
+        }
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag root) {
+        ListTag entries = new ListTag();
+        states.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey((left, right) ->
+                        left.toString().compareTo(right.toString())))
+                .forEach(saved -> entries.add(writeEntry(saved.getKey(), saved.getValue())));
+        root.put(KEY_ENTRIES, entries);
+        return root;
+    }
+
+    private static CompoundTag writeEntry(UUID companionUuid, FollowState state) {
+        CompoundTag entry = new CompoundTag();
+        entry.putUUID(KEY_COMPANION_UUID, companionUuid);
+        entry.putBoolean(KEY_ENABLED, state.enabled());
+        entry.putBoolean(KEY_MANUAL_PAUSED, state.manualPaused());
+        entry.putInt(KEY_SCHEMA_VERSION, state.schemaVersion());
+        if (state.stopDistanceOverride() != null) {
+            entry.putDouble(KEY_STOP_DISTANCE, state.stopDistanceOverride());
+        }
+        if (state.startDistanceOverride() != null) {
+            entry.putDouble(KEY_START_DISTANCE, state.startDistanceOverride());
+        }
+        return entry;
+    }
+
+    public FollowState getOrDefault(UUID companionUuid) {
+        return states.getOrDefault(companionUuid, FollowState.defaults());
+    }
+
+    public Optional<FollowState> find(UUID companionUuid) {
+        return Optional.ofNullable(states.get(companionUuid));
+    }
+
+    public Map<UUID, FollowState> snapshot() {
+        return Collections.unmodifiableMap(new HashMap<>(states));
+    }
+
+    public int size() {
+        return states.size();
+    }
+
+    public void put(UUID companionUuid, FollowState state) {
+        if (companionUuid == null || state == null) {
+            throw new IllegalArgumentException("companion UUID and follow state are required");
+        }
+        if (!state.equals(states.put(companionUuid, state))) {
+            setDirty();
+        }
+    }
+
+    public void setEnabled(UUID companionUuid, boolean enabled) {
+        put(companionUuid, getOrDefault(companionUuid).withEnabled(enabled));
+    }
+
+    public void setManualPaused(UUID companionUuid, boolean manualPaused) {
+        put(companionUuid, getOrDefault(companionUuid).withManualPaused(manualPaused));
+    }
+
+    public void setDistanceOverrides(UUID companionUuid, Double stopDistance, Double startDistance) {
+        put(companionUuid, getOrDefault(companionUuid)
+                .withDistanceOverrides(stopDistance, startDistance));
+    }
+
+    public void remove(UUID companionUuid) {
+        if (states.remove(companionUuid) != null) {
+            setDirty();
+        }
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
@@ -2,9 +2,13 @@ package com.dwinovo.numen.core.follow;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.dwinovo.numen.core.Constants;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -32,13 +36,16 @@ public final class FollowStateStore extends SavedData {
     private static final String KEY_START_DISTANCE = "startDistanceOverride";
 
     private final Map<UUID, FollowState> states;
+    private final transient Map<UUID, FollowRuntimeControl> runtimeControls;
 
     FollowStateStore() {
         this.states = new HashMap<>();
+        this.runtimeControls = new HashMap<>();
     }
 
     private FollowStateStore(Map<UUID, FollowState> states) {
         this.states = new HashMap<>(states);
+        this.runtimeControls = new HashMap<>();
     }
 
     public static FollowStateStore get(MinecraftServer server) {
@@ -185,6 +192,99 @@ public final class FollowStateStore extends SavedData {
     public void remove(UUID companionUuid) {
         if (states.remove(companionUuid) != null) {
             setDirty();
+        }
+    }
+
+    /**
+     * Binds the currently live runtime for a companion. Rebinding the same
+     * object is a no-op. A replacement becomes visible before the displaced
+     * runtime is released, so a callback from the old runtime cannot remove the
+     * new binding.
+     */
+    public void bindRuntime(UUID companionUuid, FollowRuntimeControl control) {
+        Objects.requireNonNull(companionUuid, "companionUuid");
+        Objects.requireNonNull(control, "control");
+        if (!companionUuid.equals(control.companionUuid())) {
+            throw new IllegalArgumentException(
+                    "runtime control companion UUID does not match binding key");
+        }
+
+        FollowRuntimeControl previous = runtimeControls.put(companionUuid, control);
+        if (previous == null || previous == control) {
+            return;
+        }
+        releaseSafely(previous, FollowReleaseReason.RUNTIME_REPLACED);
+    }
+
+    public Optional<FollowRuntimeControl> runtimeControl(UUID companionUuid) {
+        return Optional.ofNullable(runtimeControls.get(
+                Objects.requireNonNull(companionUuid, "companionUuid")));
+    }
+
+    public Optional<FollowRuntimeSnapshot> runtimeSnapshot(
+            UUID companionUuid, long currentGameTime) {
+        return runtimeControl(companionUuid)
+                .map(control -> control.snapshot(currentGameTime));
+    }
+
+    /**
+     * Releases movement while retaining the runtime binding for later resume.
+     */
+    public void releaseRuntime(UUID companionUuid, FollowReleaseReason reason) {
+        Objects.requireNonNull(reason, "reason");
+        FollowRuntimeControl control = runtimeControls.get(
+                Objects.requireNonNull(companionUuid, "companionUuid"));
+        if (control != null) {
+            releaseSafely(control, reason);
+        }
+    }
+
+    /**
+     * Removes the binding before release so release callbacks cannot observe a
+     * stale registered runtime.
+     */
+    public void removeRuntime(UUID companionUuid, FollowReleaseReason reason) {
+        Objects.requireNonNull(reason, "reason");
+        FollowRuntimeControl control = runtimeControls.remove(
+                Objects.requireNonNull(companionUuid, "companionUuid"));
+        if (control != null) {
+            releaseSafely(control, reason);
+        }
+    }
+
+    /**
+     * Clears all bindings before releasing a stable copy. One faulty runtime
+     * cannot prevent the others from relinquishing control.
+     *
+     * @return number of runtime releases that threw
+     */
+    public int releaseAllRuntime(FollowReleaseReason reason) {
+        Objects.requireNonNull(reason, "reason");
+        List<FollowRuntimeControl> controls = List.copyOf(runtimeControls.values());
+        runtimeControls.clear();
+        int failures = 0;
+        for (FollowRuntimeControl control : controls) {
+            if (!releaseSafely(control, reason)) {
+                failures++;
+            }
+        }
+        return failures;
+    }
+
+    int runtimeControlCount() {
+        return runtimeControls.size();
+    }
+
+    private static boolean releaseSafely(
+            FollowRuntimeControl control, FollowReleaseReason reason) {
+        try {
+            control.release(reason);
+            return true;
+        } catch (RuntimeException exception) {
+            Constants.LOG.error(
+                    "[owner-follow] failed to release a transient runtime for {}",
+                    reason, exception);
+            return false;
         }
     }
 }

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
@@ -36,7 +36,7 @@ public final class FollowStateStore extends SavedData {
     private static final String KEY_START_DISTANCE = "startDistanceOverride";
 
     private final Map<UUID, FollowState> states;
-    private final transient Map<UUID, FollowRuntimeControl> runtimeControls;
+    private final transient Map<UUID, RuntimeBinding> runtimeControls;
 
     FollowStateStore() {
         this.states = new HashMap<>();
@@ -226,23 +226,39 @@ public final class FollowStateStore extends SavedData {
      * new binding.
      */
     public void bindRuntime(UUID companionUuid, FollowRuntimeControl control) {
+        bindRuntime(companionUuid, control, control);
+    }
+
+    /**
+     * Binds a runtime to the concrete companion-body generation that owns it.
+     * The identity is compared by reference, never by UUID or value equality.
+     */
+    public void bindRuntime(
+            UUID companionUuid,
+            Object lifecycleIdentity,
+            FollowRuntimeControl control) {
         Objects.requireNonNull(companionUuid, "companionUuid");
+        Objects.requireNonNull(lifecycleIdentity, "lifecycleIdentity");
         Objects.requireNonNull(control, "control");
         if (!companionUuid.equals(control.companionUuid())) {
             throw new IllegalArgumentException(
                     "runtime control companion UUID does not match binding key");
         }
 
-        FollowRuntimeControl previous = runtimeControls.put(companionUuid, control);
-        if (previous == null || previous == control) {
+        RuntimeBinding replacement =
+                new RuntimeBinding(lifecycleIdentity, control);
+        RuntimeBinding previous =
+                runtimeControls.put(companionUuid, replacement);
+        if (previous == null || previous.control() == control) {
             return;
         }
-        releaseSafely(previous, FollowReleaseReason.RUNTIME_REPLACED);
+        releaseSafely(previous.control(), FollowReleaseReason.RUNTIME_REPLACED);
     }
 
     public Optional<FollowRuntimeControl> runtimeControl(UUID companionUuid) {
         return Optional.ofNullable(runtimeControls.get(
-                Objects.requireNonNull(companionUuid, "companionUuid")));
+                        Objects.requireNonNull(companionUuid, "companionUuid")))
+                .map(RuntimeBinding::control);
     }
 
     public Optional<FollowRuntimeSnapshot> runtimeSnapshot(
@@ -256,22 +272,30 @@ public final class FollowStateStore extends SavedData {
      */
     public boolean releaseRuntime(UUID companionUuid, FollowReleaseReason reason) {
         Objects.requireNonNull(reason, "reason");
-        FollowRuntimeControl control = runtimeControls.get(
+        RuntimeBinding binding = runtimeControls.get(
                 Objects.requireNonNull(companionUuid, "companionUuid"));
-        return control == null || releaseSafely(control, reason);
+        return binding == null || releaseSafely(binding.control(), reason);
     }
 
     /**
-     * Removes the binding before release so release callbacks cannot observe a
-     * stale registered runtime.
+     * Removes the binding before release only when the callback carries the
+     * concrete body or runtime identity that owns the current generation.
+     * Stale callbacks for an older body/control sharing the same UUID are no-ops.
      */
-    public void removeRuntime(UUID companionUuid, FollowReleaseReason reason) {
+    public void removeRuntime(
+            UUID companionUuid,
+            Object expectedIdentity,
+            FollowReleaseReason reason) {
+        Objects.requireNonNull(expectedIdentity, "expectedIdentity");
         Objects.requireNonNull(reason, "reason");
-        FollowRuntimeControl control = runtimeControls.remove(
-                Objects.requireNonNull(companionUuid, "companionUuid"));
-        if (control != null) {
-            releaseSafely(control, reason);
+        UUID checkedUuid =
+                Objects.requireNonNull(companionUuid, "companionUuid");
+        RuntimeBinding current = runtimeControls.get(checkedUuid);
+        if (current == null || !current.matches(expectedIdentity)) {
+            return;
         }
+        runtimeControls.remove(checkedUuid);
+        releaseSafely(current.control(), reason);
     }
 
     /**
@@ -282,7 +306,9 @@ public final class FollowStateStore extends SavedData {
      */
     public int releaseAllRuntime(FollowReleaseReason reason) {
         Objects.requireNonNull(reason, "reason");
-        List<FollowRuntimeControl> controls = List.copyOf(runtimeControls.values());
+        List<FollowRuntimeControl> controls = runtimeControls.values().stream()
+                .map(RuntimeBinding::control)
+                .toList();
         runtimeControls.clear();
         int failures = 0;
         for (FollowRuntimeControl control : controls) {
@@ -295,6 +321,21 @@ public final class FollowStateStore extends SavedData {
 
     int runtimeControlCount() {
         return runtimeControls.size();
+    }
+
+    private record RuntimeBinding(
+            Object lifecycleIdentity,
+            FollowRuntimeControl control) {
+
+        private RuntimeBinding {
+            Objects.requireNonNull(lifecycleIdentity, "lifecycleIdentity");
+            Objects.requireNonNull(control, "control");
+        }
+
+        private boolean matches(Object expectedIdentity) {
+            return lifecycleIdentity == expectedIdentity
+                    || control == expectedIdentity;
+        }
     }
 
     private static boolean releaseSafely(

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowStateStore.java
@@ -184,6 +184,30 @@ public final class FollowStateStore extends SavedData {
         put(companionUuid, getOrDefault(companionUuid).withManualPaused(manualPaused));
     }
 
+    /**
+     * Atomically updates both user-control bits while preserving schema and
+     * per-companion distance overrides.
+     *
+     * @return {@code true} only when persistent state actually changed
+     */
+    public boolean setControlState(
+            UUID companionUuid, boolean enabled, boolean manualPaused) {
+        Objects.requireNonNull(companionUuid, "companionUuid");
+        FollowState current = getOrDefault(companionUuid);
+        FollowState replacement = new FollowState(
+                enabled,
+                manualPaused,
+                current.schemaVersion(),
+                current.stopDistanceOverride(),
+                current.startDistanceOverride());
+        if (replacement.equals(current)) {
+            return false;
+        }
+        states.put(companionUuid, replacement);
+        setDirty();
+        return true;
+    }
+
     public void setDistanceOverrides(UUID companionUuid, Double stopDistance, Double startDistance) {
         put(companionUuid, getOrDefault(companionUuid)
                 .withDistanceOverrides(stopDistance, startDistance));
@@ -230,13 +254,11 @@ public final class FollowStateStore extends SavedData {
     /**
      * Releases movement while retaining the runtime binding for later resume.
      */
-    public void releaseRuntime(UUID companionUuid, FollowReleaseReason reason) {
+    public boolean releaseRuntime(UUID companionUuid, FollowReleaseReason reason) {
         Objects.requireNonNull(reason, "reason");
         FollowRuntimeControl control = runtimeControls.get(
                 Objects.requireNonNull(companionUuid, "companionUuid"));
-        if (control != null) {
-            releaseSafely(control, reason);
-        }
+        return control == null || releaseSafely(control, reason);
     }
 
     /**

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowStatus.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowStatus.java
@@ -1,0 +1,89 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+/**
+ * Immutable, entity-free owner-follow status shared by commands and tools.
+ */
+public record FollowStatus(
+        UUID companionUuid,
+        String companionName,
+        boolean enabled,
+        boolean manualPaused,
+        boolean runtimeAvailable,
+        FollowRuntimeState runtimeState,
+        FollowWaitingReason waitingReason,
+        boolean following,
+        boolean navigationActive,
+        boolean sprintAllowed,
+        boolean catchingUp,
+        long remainingCooldownTicks,
+        boolean ownerPresent,
+        boolean ownerOnline,
+        boolean sameDimension,
+        OptionalDouble distance,
+        double effectiveStopDistance,
+        double effectiveStartDistance,
+        double sprintDistance,
+        double catchUpDistance,
+        double lostDistance,
+        long failedCooldownTicks) {
+
+    public FollowStatus {
+        Objects.requireNonNull(companionUuid, "companionUuid");
+        companionName = Objects.requireNonNullElse(companionName, "");
+        Objects.requireNonNull(runtimeState, "runtimeState");
+        Objects.requireNonNull(waitingReason, "waitingReason");
+        distance = Objects.requireNonNull(distance, "distance");
+        remainingCooldownTicks = Math.max(0L, remainingCooldownTicks);
+    }
+
+    public String compactText() {
+        String distanceText = distance.isPresent()
+                ? String.format(Locale.ROOT, "%.2f", distance.getAsDouble())
+                : "unavailable";
+        return "同伴 " + companionName
+                + "：enabled=" + enabled
+                + ", paused=" + manualPaused
+                + ", 运行=" + runtimeDescription()
+                + ", waiting=" + waitingDescription()
+                + ", navigation=" + navigationActive
+                + ", ownerOnline=" + ownerOnline
+                + ", sameDimension=" + sameDimension
+                + ", distance=" + distanceText
+                + ", cooldown=" + remainingCooldownTicks
+                + ", thresholds={stop=" + effectiveStopDistance
+                + ", start=" + effectiveStartDistance
+                + ", sprint=" + sprintDistance
+                + ", catchUp=" + catchUpDistance
+                + ", lost=" + lostDistance
+                + ", failedCooldown=" + failedCooldownTicks + "}";
+    }
+
+    private String runtimeDescription() {
+        return switch (runtimeState) {
+            case DISABLED -> "自动跟随已关闭";
+            case MANUALLY_PAUSED -> "自动跟随已手动暂停";
+            case WAITING_FOR_OWNER -> "正在等待可跟随的主人";
+            case IDLE_NEAR_OWNER -> "已在主人附近，无需移动";
+            case FOLLOWING -> navigationActive
+                    ? "正在跟随并导航"
+                    : "已取得跟随资格，等待建立路径";
+            case FAILED_COOLDOWN -> "最近导航失败，正在冷却后重试";
+        };
+    }
+
+    private String waitingDescription() {
+        return switch (waitingReason) {
+            case NONE -> "无";
+            case OWNER_OFFLINE -> "主人当前不在线";
+            case OWNER_OTHER_DIMENSION -> "主人位于其他维度";
+            case OWNER_TOO_FAR -> "主人超过最大跟随距离";
+            case OWNER_INVALID -> "主人绑定或运行身份不可用";
+            case COMPANION_NOT_ACTIVE -> "同伴当前不可运行";
+        };
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/FollowWaitingReason.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/FollowWaitingReason.java
@@ -1,0 +1,11 @@
+package com.dwinovo.numen.core.follow;
+
+/** Transient reason why owner following is not currently eligible to run. */
+public enum FollowWaitingReason {
+    NONE,
+    OWNER_OFFLINE,
+    OWNER_OTHER_DIMENSION,
+    OWNER_TOO_FAR,
+    OWNER_INVALID,
+    COMPANION_NOT_ACTIVE
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
@@ -1,0 +1,303 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.goal.GoalCompiler;
+import com.dwinovo.numen.entity.InputDriver;
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.dwinovo.numen.task.TaskChain;
+
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Lowest-priority, per-companion owner following.
+ *
+ * <p>The chain retains only its hysteresis latch and one navigation handle.
+ * Owner resolution remains live: eligibility, winning ticks, the dynamic goal,
+ * and the arrival predicate all resolve the companion's current owner again.
+ */
+public final class OwnerFollowChain implements TaskChain {
+
+    public static final float PRIORITY = -2.0f;
+    public static final double DEFAULT_STOP_DISTANCE = 3.0;
+    public static final double DEFAULT_START_DISTANCE = 5.5;
+    public static final int REGISTRATION_ORDER = 60;
+
+    private static final double NAV_SPEED = 1.0;
+
+    private final FollowAccess followAccess;
+    private final NavigationFactory navigationFactory;
+    private final HaltAction haltAction;
+
+    private Navigation navigation;
+    private boolean following;
+
+    public OwnerFollowChain() {
+        this(new LiveFollowAccess(), OwnerFollowChain::createPlayerNavigation, InputDriver::halt);
+    }
+
+    OwnerFollowChain(FollowAccess followAccess, NavigationFactory navigationFactory,
+                     HaltAction haltAction) {
+        this.followAccess = Objects.requireNonNull(followAccess, "followAccess");
+        this.navigationFactory = Objects.requireNonNull(navigationFactory, "navigationFactory");
+        this.haltAction = Objects.requireNonNull(haltAction, "haltAction");
+    }
+
+    @Override
+    public float getPriority(NumenPlayer companion) {
+        Decision decision = decide(followAccess.snapshot(companion), following);
+        following = decision.following();
+        return decision.priority();
+    }
+
+    @Override
+    public void tick(NumenPlayer companion) {
+        Decision decision = decide(followAccess.snapshot(companion), following);
+        following = decision.following();
+        if (!decision.active()) {
+            releaseControl(companion);
+            return;
+        }
+
+        if (navigation == null) {
+            double stopDistance = decision.distances().stop();
+            Supplier<GoalCompiler.Compiled> goal =
+                    () -> followAccess.compileOwnerGoal(companion, stopDistance);
+            BooleanSupplier reached =
+                    () -> followAccess.isWithinStopDistance(companion, stopDistance);
+            navigation = navigationFactory.create(
+                    companion, goal, reached, FollowContextProvider.INSTANCE);
+        }
+
+        PlayerNav.Status status = navigation.tick();
+        if (status == PlayerNav.Status.RUNNING) {
+            return;
+        }
+
+        if (status == PlayerNav.Status.ARRIVED) {
+            Decision arrival = decide(followAccess.snapshot(companion), following);
+            following = arrival.following();
+            if (!arrival.active()) {
+                releaseControl(companion);
+            }
+            return;
+        }
+        releaseControl(companion);
+    }
+
+    @Override
+    public void onInterrupt(NumenPlayer companion) {
+        releaseControl(companion);
+    }
+
+    @Override
+    public String name() {
+        return "owner_follow";
+    }
+
+    /**
+     * Idempotently relinquishes both pathing and movement input. The hysteresis
+     * latch is intentionally retained across scheduler pre-emption.
+     */
+    private void releaseControl(NumenPlayer companion) {
+        Navigation active = navigation;
+        try {
+            if (active != null) {
+                active.stop();
+            }
+        } finally {
+            try {
+                haltAction.halt(companion);
+            } finally {
+                navigation = null;
+            }
+        }
+    }
+
+    static Decision decide(Snapshot snapshot, boolean wasFollowing) {
+        Distances distances = resolveDistances(
+                snapshot.state().stopDistanceOverride(),
+                snapshot.state().startDistanceOverride());
+
+        if (!snapshot.companionValid()
+                || !snapshot.state().enabled()
+                || snapshot.state().manualPaused()
+                || !snapshot.ownerUuidPresent()
+                || !snapshot.ownerOnline()
+                || !snapshot.ownerValid()
+                || !snapshot.sameLevel()
+                || !Double.isFinite(snapshot.distance())) {
+            return new Decision(Float.NEGATIVE_INFINITY, false, distances);
+        }
+
+        boolean nowFollowing;
+        if (snapshot.distance() <= distances.stop()) {
+            nowFollowing = false;
+        } else if (snapshot.distance() >= distances.start()) {
+            nowFollowing = true;
+        } else {
+            nowFollowing = wasFollowing;
+        }
+        return new Decision(nowFollowing ? PRIORITY : Float.NEGATIVE_INFINITY,
+                nowFollowing, distances);
+    }
+
+    static Distances resolveDistances(Double stopOverride, Double startOverride) {
+        if (stopOverride == null || startOverride == null
+                || !Double.isFinite(stopOverride) || !Double.isFinite(startOverride)
+                || stopOverride <= 0.0 || startOverride <= 0.0
+                || stopOverride >= startOverride) {
+            return new Distances(DEFAULT_STOP_DISTANCE, DEFAULT_START_DISTANCE);
+        }
+        return new Distances(stopOverride, startOverride);
+    }
+
+    static double distance3d(double firstX, double firstY, double firstZ,
+                             double secondX, double secondY, double secondZ) {
+        double dx = secondX - firstX;
+        double dy = secondY - firstY;
+        double dz = secondZ - firstZ;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    static GoalCompiler.Compiled compileNearGoal(
+            net.minecraft.core.BlockPos center, double stopDistance) {
+        return GoalCompiler.near(center, stopDistance);
+    }
+
+    boolean hasNavigation() {
+        return navigation != null;
+    }
+
+    private static Navigation createPlayerNavigation(
+            NumenPlayer companion,
+            Supplier<GoalCompiler.Compiled> goal,
+            BooleanSupplier reached,
+            PlayerNav.ContextProvider contextProvider) {
+        PlayerNav playerNav = PlayerNav.toRevalidating(
+                companion, goal, NAV_SPEED, reached, contextProvider);
+        return new Navigation() {
+            @Override
+            public PlayerNav.Status tick() {
+                return playerNav.tick();
+            }
+
+            @Override
+            public void stop() {
+                playerNav.stop();
+            }
+        };
+    }
+
+    record Distances(double stop, double start) {}
+
+    record Decision(float priority, boolean following, Distances distances) {
+        boolean active() {
+            return priority == PRIORITY;
+        }
+    }
+
+    record Snapshot(
+            FollowState state,
+            boolean companionValid,
+            boolean ownerUuidPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameLevel,
+            double distance) {
+
+        Snapshot {
+            Objects.requireNonNull(state, "state");
+        }
+    }
+
+    interface FollowAccess {
+        Snapshot snapshot(NumenPlayer companion);
+
+        GoalCompiler.Compiled compileOwnerGoal(NumenPlayer companion, double stopDistance);
+
+        boolean isWithinStopDistance(NumenPlayer companion, double stopDistance);
+    }
+
+    interface NavigationFactory {
+        Navigation create(NumenPlayer companion, Supplier<GoalCompiler.Compiled> goal,
+                          BooleanSupplier reached, PlayerNav.ContextProvider contextProvider);
+    }
+
+    interface Navigation {
+        PlayerNav.Status tick();
+
+        void stop();
+    }
+
+    interface HaltAction {
+        void halt(NumenPlayer companion);
+    }
+
+    private static final class LiveFollowAccess implements FollowAccess {
+
+        @Override
+        public Snapshot snapshot(NumenPlayer companion) {
+            boolean companionValid =
+                    companion != null && !companion.isRemoved() && companion.isAlive();
+            if (companion == null) {
+                return unavailable(companionValid, false);
+            }
+
+            FollowState state = FollowStateStore.get(companion.level().getServer())
+                    .getOrDefault(companion.getUUID());
+            boolean ownerUuidPresent = companion.getOwnerUuid() != null;
+            if (!companionValid || !ownerUuidPresent) {
+                return new Snapshot(state, companionValid, ownerUuidPresent,
+                        false, false, false, Double.NaN);
+            }
+
+            ServerPlayer owner = companion.resolveOwnerPlayer();
+            boolean ownerOnline = owner != null;
+            boolean ownerValid = ownerOnline && !owner.isRemoved() && owner.isAlive();
+            boolean sameLevel = ownerValid && owner.level() == companion.level();
+            double distance = sameLevel
+                    ? distance3d(companion.getX(), companion.getY(), companion.getZ(),
+                            owner.getX(), owner.getY(), owner.getZ())
+                    : Double.NaN;
+            return new Snapshot(state, companionValid, ownerUuidPresent,
+                    ownerOnline, ownerValid, sameLevel, distance);
+        }
+
+        @Override
+        public GoalCompiler.Compiled compileOwnerGoal(
+                NumenPlayer companion, double stopDistance) {
+            ServerPlayer owner = resolveLiveSameLevelOwner(companion);
+            return owner == null ? null : compileNearGoal(owner.blockPosition(), stopDistance);
+        }
+
+        @Override
+        public boolean isWithinStopDistance(NumenPlayer companion, double stopDistance) {
+            ServerPlayer owner = resolveLiveSameLevelOwner(companion);
+            return owner != null
+                    && distance3d(companion.getX(), companion.getY(), companion.getZ(),
+                            owner.getX(), owner.getY(), owner.getZ()) <= stopDistance;
+        }
+
+        private static Snapshot unavailable(boolean companionValid, boolean ownerUuidPresent) {
+            return new Snapshot(FollowState.defaults(), companionValid, ownerUuidPresent,
+                    false, false, false, Double.NaN);
+        }
+
+        private static ServerPlayer resolveLiveSameLevelOwner(NumenPlayer companion) {
+            if (companion == null || companion.isRemoved() || !companion.isAlive()
+                    || companion.getOwnerUuid() == null) {
+                return null;
+            }
+            ServerPlayer owner = companion.resolveOwnerPlayer();
+            if (owner == null || owner.isRemoved() || !owner.isAlive()
+                    || owner.level() != companion.level()) {
+                return null;
+            }
+            return owner;
+        }
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
@@ -44,6 +44,7 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
     private final FollowAccess followAccess;
     private final NavigationFactory navigationFactory;
     private final HaltAction haltAction;
+    private final FollowConfig config;
 
     private Navigation navigation;
     private FollowRuntimeState runtimeState = FollowRuntimeState.DISABLED;
@@ -59,14 +60,25 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
     private transient FollowStateStore boundStore;
 
     public OwnerFollowChain() {
-        this(new LiveFollowAccess(), OwnerFollowChain::createPlayerNavigation, InputDriver::halt);
+        this(FollowConfig.defaults());
+    }
+
+    public OwnerFollowChain(FollowConfig config) {
+        this(new LiveFollowAccess(), OwnerFollowChain::createPlayerNavigation,
+                InputDriver::halt, config);
     }
 
     OwnerFollowChain(FollowAccess followAccess, NavigationFactory navigationFactory,
                      HaltAction haltAction) {
+        this(followAccess, navigationFactory, haltAction, FollowConfig.defaults());
+    }
+
+    OwnerFollowChain(FollowAccess followAccess, NavigationFactory navigationFactory,
+                     HaltAction haltAction, FollowConfig config) {
         this.followAccess = Objects.requireNonNull(followAccess, "followAccess");
         this.navigationFactory = Objects.requireNonNull(navigationFactory, "navigationFactory");
         this.haltAction = Objects.requireNonNull(haltAction, "haltAction");
+        this.config = Objects.requireNonNull(config, "config");
     }
 
     @Override
@@ -74,7 +86,7 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
         ensureBound(companion);
         Snapshot snapshot = followAccess.snapshot(companion);
         observe(snapshot);
-        Decision decision = decide(snapshot, following, failedUntilTick);
+        Decision decision = decide(snapshot, following, failedUntilTick, config);
         apply(decision);
         return decision.priority();
     }
@@ -84,7 +96,7 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
         ensureBound(companion);
         Snapshot snapshot = followAccess.snapshot(companion);
         observe(snapshot);
-        Decision decision = decide(snapshot, following, failedUntilTick);
+        Decision decision = decide(snapshot, following, failedUntilTick, config);
         apply(decision);
         if (!decision.active()) {
             releaseControl(inactiveReason(snapshot), companion, true);
@@ -110,7 +122,8 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
         if (status == PlayerNav.Status.ARRIVED) {
             Snapshot arrivalSnapshot = followAccess.snapshot(companion);
             observe(arrivalSnapshot);
-            Decision arrival = decide(arrivalSnapshot, following, failedUntilTick);
+            Decision arrival = decide(
+                    arrivalSnapshot, following, failedUntilTick, config);
             apply(arrival);
             if (!arrival.active()) {
                 releaseControl(inactiveReason(arrivalSnapshot), companion, true);
@@ -120,7 +133,7 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
         if (status == PlayerNav.Status.FAILED) {
             releaseControl(
                     FollowReleaseReason.INTERNAL_STATE_CHANGE, companion, true);
-            apply(failedAt(decision, snapshot.gameTime()));
+            apply(failedAt(decision, snapshot.gameTime(), config));
         }
     }
 
@@ -293,18 +306,38 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
 
     static Decision decide(
             Snapshot snapshot, boolean wasFollowing, long failedUntilTick) {
+        return decide(snapshot, wasFollowing, failedUntilTick, FollowConfig.defaults());
+    }
+
+    static Decision decide(
+            Snapshot snapshot,
+            boolean wasFollowing,
+            long failedUntilTick,
+            FollowConfig config) {
         FollowDecisions.Result result = FollowDecisions.decide(
-                toInput(snapshot), wasFollowing, failedUntilTick);
+                toInput(snapshot), wasFollowing, failedUntilTick, config);
         return fromResult(result);
     }
 
     static Decision failedAt(Decision previous, long currentTick) {
-        return fromResult(FollowDecisions.failedAt(toResult(previous), currentTick));
+        return failedAt(previous, currentTick, FollowConfig.defaults());
+    }
+
+    static Decision failedAt(
+            Decision previous, long currentTick, FollowConfig config) {
+        return fromResult(
+                FollowDecisions.failedAt(toResult(previous), currentTick, config));
     }
 
     static Distances resolveDistances(Double stopOverride, Double startOverride) {
+        return resolveDistances(
+                stopOverride, startOverride, FollowConfig.defaults());
+    }
+
+    static Distances resolveDistances(
+            Double stopOverride, Double startOverride, FollowConfig config) {
         FollowDecisions.Distances distances =
-                FollowDecisions.resolveDistances(stopOverride, startOverride);
+                FollowDecisions.resolveDistances(stopOverride, startOverride, config);
         return new Distances(distances.stop(), distances.start());
     }
 
@@ -329,6 +362,10 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
 
     long remainingCooldownTicks(long currentTick) {
         return FollowDecisions.remainingCooldownTicks(failedUntilTick, currentTick);
+    }
+
+    FollowConfig config() {
+        return config;
     }
 
     private void apply(Decision decision) {

--- a/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
@@ -1,6 +1,7 @@
 package com.dwinovo.numen.core.follow;
 
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -11,6 +12,7 @@ import com.dwinovo.numen.entity.NumenPlayer;
 import com.dwinovo.numen.task.TaskChain;
 
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.MinecraftServer;
 
 /**
  * Lowest-priority, per-companion owner following.
@@ -20,7 +22,7 @@ import net.minecraft.server.level.ServerPlayer;
  * ticks, the dynamic goal, and the arrival predicate all resolve the
  * companion's current owner again.
  */
-public final class OwnerFollowChain implements TaskChain {
+public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
 
     public static final float PRIORITY = FollowDecisions.PRIORITY;
     public static final double DEFAULT_STOP_DISTANCE =
@@ -50,6 +52,11 @@ public final class OwnerFollowChain implements TaskChain {
     private boolean sprintAllowed;
     private boolean catchingUp;
     private long failedUntilTick = FollowDecisions.NO_FAILED_COOLDOWN;
+    private long lastObservedGameTime;
+    private transient UUID boundCompanionUuid;
+    private transient UUID terminalCompanionUuid;
+    private transient NumenPlayer boundCompanion;
+    private transient FollowStateStore boundStore;
 
     public OwnerFollowChain() {
         this(new LiveFollowAccess(), OwnerFollowChain::createPlayerNavigation, InputDriver::halt);
@@ -64,19 +71,23 @@ public final class OwnerFollowChain implements TaskChain {
 
     @Override
     public float getPriority(NumenPlayer companion) {
-        Decision decision = decide(
-                followAccess.snapshot(companion), following, failedUntilTick);
+        ensureBound(companion);
+        Snapshot snapshot = followAccess.snapshot(companion);
+        observe(snapshot);
+        Decision decision = decide(snapshot, following, failedUntilTick);
         apply(decision);
         return decision.priority();
     }
 
     @Override
     public void tick(NumenPlayer companion) {
+        ensureBound(companion);
         Snapshot snapshot = followAccess.snapshot(companion);
+        observe(snapshot);
         Decision decision = decide(snapshot, following, failedUntilTick);
         apply(decision);
         if (!decision.active()) {
-            releaseControl(companion);
+            releaseControl(inactiveReason(snapshot), companion, true);
             return;
         }
 
@@ -97,23 +108,25 @@ public final class OwnerFollowChain implements TaskChain {
         }
 
         if (status == PlayerNav.Status.ARRIVED) {
-            Decision arrival = decide(
-                    followAccess.snapshot(companion), following, failedUntilTick);
+            Snapshot arrivalSnapshot = followAccess.snapshot(companion);
+            observe(arrivalSnapshot);
+            Decision arrival = decide(arrivalSnapshot, following, failedUntilTick);
             apply(arrival);
             if (!arrival.active()) {
-                releaseControl(companion);
+                releaseControl(inactiveReason(arrivalSnapshot), companion, true);
             }
             return;
         }
         if (status == PlayerNav.Status.FAILED) {
-            releaseControl(companion);
+            releaseControl(
+                    FollowReleaseReason.INTERNAL_STATE_CHANGE, companion, true);
             apply(failedAt(decision, snapshot.gameTime()));
         }
     }
 
     @Override
     public void onInterrupt(NumenPlayer companion) {
-        releaseControl(companion);
+        releaseControl(FollowReleaseReason.SCHEDULER_INTERRUPT, companion, true);
     }
 
     @Override
@@ -121,25 +134,157 @@ public final class OwnerFollowChain implements TaskChain {
         return "owner_follow";
     }
 
+    @Override
+    public UUID companionUuid() {
+        return boundCompanionUuid;
+    }
+
+    @Override
+    public void release(FollowReleaseReason reason) {
+        releaseControl(Objects.requireNonNull(reason, "reason"), null, false);
+    }
+
+    @Override
+    public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+        return new FollowRuntimeSnapshot(
+                runtimeState,
+                waitingReason,
+                following,
+                navigation != null,
+                sprintAllowed,
+                catchingUp,
+                failedUntilTick,
+                FollowDecisions.remainingCooldownTicks(
+                        failedUntilTick, currentGameTime));
+    }
+
     /**
-     * Idempotently relinquishes both pathing and movement input. The hysteresis
-     * latch is intentionally retained across scheduler pre-emption.
+     * Idempotently relinquishes pathing and movement input, then applies the
+     * reason-specific transient-state policy. It never changes persistent
+     * {@link FollowState}.
      */
-    private void releaseControl(NumenPlayer companion) {
+    private void releaseControl(
+            FollowReleaseReason reason,
+            NumenPlayer immediateCompanion,
+            boolean haltWithoutBoundForSchedulerCall) {
         Navigation active = navigation;
+        NumenPlayer haltTarget =
+                immediateCompanion != null ? immediateCompanion : boundCompanion;
+        RuntimeException failure = null;
         try {
             if (active != null) {
                 active.stop();
             }
+        } catch (RuntimeException exception) {
+            failure = exception;
+        }
+        try {
+            if (haltTarget != null || haltWithoutBoundForSchedulerCall) {
+                haltAction.halt(haltTarget);
+            }
+        } catch (RuntimeException exception) {
+            if (failure == null) {
+                failure = exception;
+            } else {
+                failure.addSuppressed(exception);
+            }
         } finally {
-            try {
-                haltAction.halt(companion);
-            } finally {
-                navigation = null;
-                sprintAllowed = false;
-                catchingUp = false;
+            navigation = null;
+            sprintAllowed = false;
+            catchingUp = false;
+        }
+
+        applyReleaseState(reason);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void applyReleaseState(FollowReleaseReason reason) {
+        switch (reason) {
+            case SCHEDULER_INTERRUPT, INTERNAL_STATE_CHANGE -> {
+                // Preserve the Stage 4 hysteresis latch and failure deadline.
+            }
+            case FOLLOW_DISABLED -> resetRuntime(
+                    FollowRuntimeState.DISABLED, FollowWaitingReason.NONE, false);
+            case MANUAL_PAUSE -> resetRuntime(
+                    FollowRuntimeState.MANUALLY_PAUSED, FollowWaitingReason.NONE, false);
+            case COMPANION_DEATH, COMPANION_REMOVED -> {
+                resetRuntime(FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.COMPANION_NOT_ACTIVE, true);
+            }
+            case SERVER_STOPPING, RUNTIME_REPLACED -> {
+                resetRuntime(FollowRuntimeState.DISABLED,
+                        FollowWaitingReason.NONE, true);
             }
         }
+    }
+
+    private void resetRuntime(
+            FollowRuntimeState newState,
+            FollowWaitingReason newWaitingReason,
+            boolean terminateBinding) {
+        runtimeState = newState;
+        waitingReason = newWaitingReason;
+        following = false;
+        failedUntilTick = FollowDecisions.NO_FAILED_COOLDOWN;
+        if (terminateBinding) {
+            terminalCompanionUuid = boundCompanionUuid;
+            boundCompanionUuid = null;
+            boundCompanion = null;
+            boundStore = null;
+        }
+    }
+
+    private void ensureBound(NumenPlayer companion) {
+        if (companion == null || companion.isRemoved() || !companion.isAlive()) {
+            return;
+        }
+        MinecraftServer server = companion.level().getServer();
+        if (server == null) {
+            return;
+        }
+
+        UUID companionUuid = companion.getUUID();
+        if (companionUuid.equals(terminalCompanionUuid)) {
+            return;
+        }
+        FollowStateStore store = FollowStateStore.get(server);
+        if (companionUuid.equals(boundCompanionUuid) && store == boundStore) {
+            boundCompanion = companion;
+            return;
+        }
+
+        if (boundCompanionUuid != null && boundStore != null) {
+            UUID previousUuid = boundCompanionUuid;
+            try {
+                boundStore.removeRuntime(
+                        previousUuid, FollowReleaseReason.RUNTIME_REPLACED);
+            } finally {
+                if (previousUuid.equals(terminalCompanionUuid)) {
+                    terminalCompanionUuid = null;
+                }
+            }
+        }
+
+        boundCompanionUuid = companionUuid;
+        boundCompanion = companion;
+        boundStore = store;
+        store.bindRuntime(companionUuid, this);
+    }
+
+    private void observe(Snapshot snapshot) {
+        lastObservedGameTime = snapshot.gameTime();
+    }
+
+    private static FollowReleaseReason inactiveReason(Snapshot snapshot) {
+        if (!snapshot.state().enabled()) {
+            return FollowReleaseReason.FOLLOW_DISABLED;
+        }
+        if (snapshot.state().manualPaused()) {
+            return FollowReleaseReason.MANUAL_PAUSE;
+        }
+        return FollowReleaseReason.INTERNAL_STATE_CHANGE;
     }
 
     static Decision decide(Snapshot snapshot, boolean wasFollowing) {
@@ -178,9 +323,8 @@ public final class OwnerFollowChain implements TaskChain {
         return navigation != null;
     }
 
-    RuntimeView runtimeView() {
-        return new RuntimeView(runtimeState, waitingReason, following,
-                sprintAllowed, catchingUp, failedUntilTick, navigation != null);
+    FollowRuntimeSnapshot runtimeView() {
+        return snapshot(lastObservedGameTime);
     }
 
     long remainingCooldownTicks(long currentTick) {
@@ -255,15 +399,6 @@ public final class OwnerFollowChain implements TaskChain {
                     sameLevel, distance, 0L);
         }
     }
-
-    record RuntimeView(
-            FollowRuntimeState runtimeState,
-            FollowWaitingReason waitingReason,
-            boolean following,
-            boolean sprintAllowed,
-            boolean catchingUp,
-            long failedUntilTick,
-            boolean navigationActive) {}
 
     interface FollowAccess {
         Snapshot snapshot(NumenPlayer companion);

--- a/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
@@ -264,6 +264,9 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
         }
         FollowStateStore store = FollowStateStore.get(server);
         if (companionUuid.equals(boundCompanionUuid) && store == boundStore) {
+            if (boundCompanion != companion) {
+                store.bindRuntime(companionUuid, companion, this);
+            }
             boundCompanion = companion;
             return;
         }
@@ -272,7 +275,8 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
             UUID previousUuid = boundCompanionUuid;
             try {
                 boundStore.removeRuntime(
-                        previousUuid, FollowReleaseReason.RUNTIME_REPLACED);
+                        previousUuid, this,
+                        FollowReleaseReason.RUNTIME_REPLACED);
             } finally {
                 if (previousUuid.equals(terminalCompanionUuid)) {
                     terminalCompanionUuid = null;
@@ -283,7 +287,7 @@ public final class OwnerFollowChain implements TaskChain, FollowRuntimeControl {
         boundCompanionUuid = companionUuid;
         boundCompanion = companion;
         boundStore = store;
-        store.bindRuntime(companionUuid, this);
+        store.bindRuntime(companionUuid, companion, this);
     }
 
     private void observe(Snapshot snapshot) {

--- a/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
+++ b/common/src/main/java/com/dwinovo/numen/core/follow/OwnerFollowChain.java
@@ -15,15 +15,26 @@ import net.minecraft.server.level.ServerPlayer;
 /**
  * Lowest-priority, per-companion owner following.
  *
- * <p>The chain retains only its hysteresis latch and one navigation handle.
- * Owner resolution remains live: eligibility, winning ticks, the dynamic goal,
- * and the arrival predicate all resolve the companion's current owner again.
+ * <p>The chain retains per-companion transient runtime state and at most one
+ * navigation handle. Owner resolution remains live: eligibility, winning
+ * ticks, the dynamic goal, and the arrival predicate all resolve the
+ * companion's current owner again.
  */
 public final class OwnerFollowChain implements TaskChain {
 
-    public static final float PRIORITY = -2.0f;
-    public static final double DEFAULT_STOP_DISTANCE = 3.0;
-    public static final double DEFAULT_START_DISTANCE = 5.5;
+    public static final float PRIORITY = FollowDecisions.PRIORITY;
+    public static final double DEFAULT_STOP_DISTANCE =
+            FollowDecisions.DEFAULT_STOP_DISTANCE;
+    public static final double DEFAULT_START_DISTANCE =
+            FollowDecisions.DEFAULT_START_DISTANCE;
+    public static final double DEFAULT_SPRINT_DISTANCE =
+            FollowDecisions.DEFAULT_SPRINT_DISTANCE;
+    public static final double DEFAULT_CATCH_UP_DISTANCE =
+            FollowDecisions.DEFAULT_CATCH_UP_DISTANCE;
+    public static final double DEFAULT_LOST_DISTANCE =
+            FollowDecisions.DEFAULT_LOST_DISTANCE;
+    public static final long FAILED_COOLDOWN_TICKS =
+            FollowDecisions.FAILED_COOLDOWN_TICKS;
     public static final int REGISTRATION_ORDER = 60;
 
     private static final double NAV_SPEED = 1.0;
@@ -33,7 +44,12 @@ public final class OwnerFollowChain implements TaskChain {
     private final HaltAction haltAction;
 
     private Navigation navigation;
+    private FollowRuntimeState runtimeState = FollowRuntimeState.DISABLED;
+    private FollowWaitingReason waitingReason = FollowWaitingReason.NONE;
     private boolean following;
+    private boolean sprintAllowed;
+    private boolean catchingUp;
+    private long failedUntilTick = FollowDecisions.NO_FAILED_COOLDOWN;
 
     public OwnerFollowChain() {
         this(new LiveFollowAccess(), OwnerFollowChain::createPlayerNavigation, InputDriver::halt);
@@ -48,15 +64,17 @@ public final class OwnerFollowChain implements TaskChain {
 
     @Override
     public float getPriority(NumenPlayer companion) {
-        Decision decision = decide(followAccess.snapshot(companion), following);
-        following = decision.following();
+        Decision decision = decide(
+                followAccess.snapshot(companion), following, failedUntilTick);
+        apply(decision);
         return decision.priority();
     }
 
     @Override
     public void tick(NumenPlayer companion) {
-        Decision decision = decide(followAccess.snapshot(companion), following);
-        following = decision.following();
+        Snapshot snapshot = followAccess.snapshot(companion);
+        Decision decision = decide(snapshot, following, failedUntilTick);
+        apply(decision);
         if (!decision.active()) {
             releaseControl(companion);
             return;
@@ -69,7 +87,8 @@ public final class OwnerFollowChain implements TaskChain {
             BooleanSupplier reached =
                     () -> followAccess.isWithinStopDistance(companion, stopDistance);
             navigation = navigationFactory.create(
-                    companion, goal, reached, FollowContextProvider.INSTANCE);
+                    companion, goal, reached, FollowContextProvider.INSTANCE,
+                    () -> sprintAllowed);
         }
 
         PlayerNav.Status status = navigation.tick();
@@ -78,14 +97,18 @@ public final class OwnerFollowChain implements TaskChain {
         }
 
         if (status == PlayerNav.Status.ARRIVED) {
-            Decision arrival = decide(followAccess.snapshot(companion), following);
-            following = arrival.following();
+            Decision arrival = decide(
+                    followAccess.snapshot(companion), following, failedUntilTick);
+            apply(arrival);
             if (!arrival.active()) {
                 releaseControl(companion);
             }
             return;
         }
-        releaseControl(companion);
+        if (status == PlayerNav.Status.FAILED) {
+            releaseControl(companion);
+            apply(failedAt(decision, snapshot.gameTime()));
+        }
     }
 
     @Override
@@ -113,54 +136,37 @@ public final class OwnerFollowChain implements TaskChain {
                 haltAction.halt(companion);
             } finally {
                 navigation = null;
+                sprintAllowed = false;
+                catchingUp = false;
             }
         }
     }
 
     static Decision decide(Snapshot snapshot, boolean wasFollowing) {
-        Distances distances = resolveDistances(
-                snapshot.state().stopDistanceOverride(),
-                snapshot.state().startDistanceOverride());
+        return decide(snapshot, wasFollowing, FollowDecisions.NO_FAILED_COOLDOWN);
+    }
 
-        if (!snapshot.companionValid()
-                || !snapshot.state().enabled()
-                || snapshot.state().manualPaused()
-                || !snapshot.ownerUuidPresent()
-                || !snapshot.ownerOnline()
-                || !snapshot.ownerValid()
-                || !snapshot.sameLevel()
-                || !Double.isFinite(snapshot.distance())) {
-            return new Decision(Float.NEGATIVE_INFINITY, false, distances);
-        }
+    static Decision decide(
+            Snapshot snapshot, boolean wasFollowing, long failedUntilTick) {
+        FollowDecisions.Result result = FollowDecisions.decide(
+                toInput(snapshot), wasFollowing, failedUntilTick);
+        return fromResult(result);
+    }
 
-        boolean nowFollowing;
-        if (snapshot.distance() <= distances.stop()) {
-            nowFollowing = false;
-        } else if (snapshot.distance() >= distances.start()) {
-            nowFollowing = true;
-        } else {
-            nowFollowing = wasFollowing;
-        }
-        return new Decision(nowFollowing ? PRIORITY : Float.NEGATIVE_INFINITY,
-                nowFollowing, distances);
+    static Decision failedAt(Decision previous, long currentTick) {
+        return fromResult(FollowDecisions.failedAt(toResult(previous), currentTick));
     }
 
     static Distances resolveDistances(Double stopOverride, Double startOverride) {
-        if (stopOverride == null || startOverride == null
-                || !Double.isFinite(stopOverride) || !Double.isFinite(startOverride)
-                || stopOverride <= 0.0 || startOverride <= 0.0
-                || stopOverride >= startOverride) {
-            return new Distances(DEFAULT_STOP_DISTANCE, DEFAULT_START_DISTANCE);
-        }
-        return new Distances(stopOverride, startOverride);
+        FollowDecisions.Distances distances =
+                FollowDecisions.resolveDistances(stopOverride, startOverride);
+        return new Distances(distances.stop(), distances.start());
     }
 
     static double distance3d(double firstX, double firstY, double firstZ,
                              double secondX, double secondY, double secondZ) {
-        double dx = secondX - firstX;
-        double dy = secondY - firstY;
-        double dz = secondZ - firstZ;
-        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+        return FollowDecisions.distance3d(
+                firstX, firstY, firstZ, secondX, secondY, secondZ);
     }
 
     static GoalCompiler.Compiled compileNearGoal(
@@ -172,13 +178,32 @@ public final class OwnerFollowChain implements TaskChain {
         return navigation != null;
     }
 
+    RuntimeView runtimeView() {
+        return new RuntimeView(runtimeState, waitingReason, following,
+                sprintAllowed, catchingUp, failedUntilTick, navigation != null);
+    }
+
+    long remainingCooldownTicks(long currentTick) {
+        return FollowDecisions.remainingCooldownTicks(failedUntilTick, currentTick);
+    }
+
+    private void apply(Decision decision) {
+        runtimeState = decision.runtimeState();
+        waitingReason = decision.waitingReason();
+        following = decision.following();
+        sprintAllowed = decision.sprintAllowed();
+        catchingUp = decision.catchingUp();
+        failedUntilTick = decision.failedUntilTick();
+    }
+
     private static Navigation createPlayerNavigation(
             NumenPlayer companion,
             Supplier<GoalCompiler.Compiled> goal,
             BooleanSupplier reached,
-            PlayerNav.ContextProvider contextProvider) {
+            PlayerNav.ContextProvider contextProvider,
+            BooleanSupplier sprintAllowed) {
         PlayerNav playerNav = PlayerNav.toRevalidating(
-                companion, goal, NAV_SPEED, reached, contextProvider);
+                companion, goal, NAV_SPEED, reached, contextProvider, sprintAllowed);
         return new Navigation() {
             @Override
             public PlayerNav.Status tick() {
@@ -194,7 +219,16 @@ public final class OwnerFollowChain implements TaskChain {
 
     record Distances(double stop, double start) {}
 
-    record Decision(float priority, boolean following, Distances distances) {
+    record Decision(
+            float priority,
+            boolean following,
+            Distances distances,
+            FollowRuntimeState runtimeState,
+            FollowWaitingReason waitingReason,
+            boolean sprintAllowed,
+            boolean catchingUp,
+            long failedUntilTick) {
+
         boolean active() {
             return priority == PRIORITY;
         }
@@ -207,12 +241,29 @@ public final class OwnerFollowChain implements TaskChain {
             boolean ownerOnline,
             boolean ownerValid,
             boolean sameLevel,
-            double distance) {
+            double distance,
+            long gameTime) {
 
         Snapshot {
             Objects.requireNonNull(state, "state");
         }
+
+        Snapshot(FollowState state, boolean companionValid, boolean ownerUuidPresent,
+                 boolean ownerOnline, boolean ownerValid, boolean sameLevel,
+                 double distance) {
+            this(state, companionValid, ownerUuidPresent, ownerOnline, ownerValid,
+                    sameLevel, distance, 0L);
+        }
     }
+
+    record RuntimeView(
+            FollowRuntimeState runtimeState,
+            FollowWaitingReason waitingReason,
+            boolean following,
+            boolean sprintAllowed,
+            boolean catchingUp,
+            long failedUntilTick,
+            boolean navigationActive) {}
 
     interface FollowAccess {
         Snapshot snapshot(NumenPlayer companion);
@@ -224,7 +275,8 @@ public final class OwnerFollowChain implements TaskChain {
 
     interface NavigationFactory {
         Navigation create(NumenPlayer companion, Supplier<GoalCompiler.Compiled> goal,
-                          BooleanSupplier reached, PlayerNav.ContextProvider contextProvider);
+                          BooleanSupplier reached, PlayerNav.ContextProvider contextProvider,
+                          BooleanSupplier sprintAllowed);
     }
 
     interface Navigation {
@@ -247,12 +299,13 @@ public final class OwnerFollowChain implements TaskChain {
                 return unavailable(companionValid, false);
             }
 
+            long gameTime = companion.level().getGameTime();
             FollowState state = FollowStateStore.get(companion.level().getServer())
                     .getOrDefault(companion.getUUID());
             boolean ownerUuidPresent = companion.getOwnerUuid() != null;
             if (!companionValid || !ownerUuidPresent) {
                 return new Snapshot(state, companionValid, ownerUuidPresent,
-                        false, false, false, Double.NaN);
+                        false, false, false, Double.NaN, gameTime);
             }
 
             ServerPlayer owner = companion.resolveOwnerPlayer();
@@ -264,7 +317,7 @@ public final class OwnerFollowChain implements TaskChain {
                             owner.getX(), owner.getY(), owner.getZ())
                     : Double.NaN;
             return new Snapshot(state, companionValid, ownerUuidPresent,
-                    ownerOnline, ownerValid, sameLevel, distance);
+                    ownerOnline, ownerValid, sameLevel, distance, gameTime);
         }
 
         @Override
@@ -299,5 +352,47 @@ public final class OwnerFollowChain implements TaskChain {
             }
             return owner;
         }
+    }
+
+    private static FollowDecisions.Input toInput(Snapshot snapshot) {
+        FollowState state = snapshot.state();
+        return new FollowDecisions.Input(
+                state.enabled(),
+                state.manualPaused(),
+                snapshot.companionValid(),
+                snapshot.ownerUuidPresent(),
+                snapshot.ownerOnline(),
+                snapshot.ownerValid(),
+                snapshot.sameLevel(),
+                snapshot.distance(),
+                state.stopDistanceOverride(),
+                state.startDistanceOverride(),
+                snapshot.gameTime());
+    }
+
+    private static Decision fromResult(FollowDecisions.Result result) {
+        FollowDecisions.Distances resolved = result.distances();
+        return new Decision(
+                result.priority(),
+                result.following(),
+                new Distances(resolved.stop(), resolved.start()),
+                result.runtimeState(),
+                result.waitingReason(),
+                result.sprintAllowed(),
+                result.catchingUp(),
+                result.failedUntilTick());
+    }
+
+    private static FollowDecisions.Result toResult(Decision decision) {
+        Distances distances = decision.distances();
+        return new FollowDecisions.Result(
+                decision.runtimeState(),
+                decision.waitingReason(),
+                decision.priority(),
+                decision.following(),
+                decision.sprintAllowed(),
+                decision.catchingUp(),
+                decision.failedUntilTick(),
+                new FollowDecisions.Distances(distances.stop(), distances.start()));
     }
 }

--- a/common/src/main/java/com/dwinovo/numen/core/pathing/exec/PlayerNav.java
+++ b/common/src/main/java/com/dwinovo/numen/core/pathing/exec/PlayerNav.java
@@ -1,6 +1,7 @@
 package com.dwinovo.numen.core.pathing.exec;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -74,7 +75,7 @@ public final class PlayerNav {
      * 物理),这里把它路由成疾跑门:speed &lt; 1.0 表示"慢速",本导航
      * 的每个 tick 里禁疾跑(见 {@link #tick} 的 allowSprint 包夹)。
      */
-    private final boolean sprintAllowed;
+    private final BooleanSupplier sprintAllowed;
 
     /** 段规划状态机:搜索派发、段执行、无缝接段、失败自动重搜全在其内。 */
     private final PathingCore core;
@@ -157,6 +158,21 @@ public final class PlayerNav {
         return new PlayerNav(player, speed, reached, compiled, true, contextProvider);
     }
 
+    /**
+     * Revalidating navigation with an additional, per-navigation dynamic sprint
+     * permission. The legacy speed gate still applies.
+     */
+    public static PlayerNav toRevalidating(
+            NumenPlayer player,
+            Supplier<GoalCompiler.Compiled> compiled,
+            double speed,
+            BooleanSupplier reached,
+            ContextProvider contextProvider,
+            BooleanSupplier sprintAllowed) {
+        return new PlayerNav(player, speed, reached, compiled, true, contextProvider,
+                combinedSprintGate(speed, sprintAllowed));
+    }
+
     /** 持续跟随一个实时实体,每 tick 用实体当前脚位重新校验目标。 */
     public static PlayerNav followEntity(NumenPlayer player, Supplier<? extends Entity> entitySupplier,
                                          double followRadius, double speed, BooleanSupplier reached) {
@@ -210,9 +226,17 @@ public final class PlayerNav {
     private PlayerNav(NumenPlayer player, double speed, BooleanSupplier reached,
                       Supplier<GoalCompiler.Compiled> compiledSupplier,
                       boolean revalidateGoalEachTick, ContextProvider contextProvider) {
+        this(player, speed, reached, compiledSupplier, revalidateGoalEachTick,
+                contextProvider, legacySprintGate(speed));
+    }
+
+    private PlayerNav(NumenPlayer player, double speed, BooleanSupplier reached,
+                      Supplier<GoalCompiler.Compiled> compiledSupplier,
+                      boolean revalidateGoalEachTick, ContextProvider contextProvider,
+                      BooleanSupplier sprintAllowed) {
         this.player = player;
         this.compiledSupplier = compiledSupplier;
-        this.sprintAllowed = speed >= 1.0;
+        this.sprintAllowed = Objects.requireNonNull(sprintAllowed, "sprintAllowed");
         this.reached = reached;
         this.contextProvider = contextProvider == null ? ContextProvider.DEFAULT : contextProvider;
         this.revalidateGoalEachTick = revalidateGoalEachTick;
@@ -346,14 +370,30 @@ public final class PlayerNav {
      * 不影响别的同伴。
      */
     private void withSprintGate(Runnable body) {
+        withSprintGate(sprintAllowed, body);
+    }
+
+    static void withSprintGate(BooleanSupplier sprintAllowed, Runnable body) {
+        Objects.requireNonNull(sprintAllowed, "sprintAllowed");
+        Objects.requireNonNull(body, "body");
         NavSettings settings = NavSettings.get();
         boolean saved = settings.allowSprint;
-        settings.allowSprint = saved && sprintAllowed;
+        settings.allowSprint = saved && sprintAllowed.getAsBoolean();
         try {
             body.run();
         } finally {
             settings.allowSprint = saved;
         }
+    }
+
+    static BooleanSupplier legacySprintGate(double speed) {
+        return () -> speed >= 1.0;
+    }
+
+    static BooleanSupplier combinedSprintGate(
+            double speed, BooleanSupplier sprintAllowed) {
+        Objects.requireNonNull(sprintAllowed, "sprintAllowed");
+        return () -> speed >= 1.0 && sprintAllowed.getAsBoolean();
     }
 
     /**
@@ -463,5 +503,4 @@ public final class PlayerNav {
         player.setShiftKeyDown(false);
     }
 }
-
 

--- a/common/src/main/java/com/dwinovo/numen/core/pathing/execute/PathExecutor.java
+++ b/common/src/main/java/com/dwinovo/numen/core/pathing/execute/PathExecutor.java
@@ -20,6 +20,7 @@ import com.dwinovo.numen.core.pathing.moves.MovementHelper;
 import com.dwinovo.numen.core.pathing.moves.MovementState;
 import com.dwinovo.numen.core.pathing.moves.MovementStatus;
 import com.dwinovo.numen.core.pathing.moves.MutableMoveResult;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
 import com.dwinovo.numen.core.pathing.moves.movements.MovementAscend;
 import com.dwinovo.numen.core.pathing.moves.movements.MovementDescend;
 import com.dwinovo.numen.core.pathing.moves.movements.MovementDiagonal;
@@ -161,7 +162,6 @@ public final class PathExecutor {
             return true;
         }
         Movement movement = path.movements().get(pathPosition);
-        movement.setExecutionDelegate(harness);
         BlockPos feet = playerFeet(player);
         boolean inValid = movement.getValidPositions().contains(feet);
         if (tickRecursionDepth < 6 && !inValid) {
@@ -294,6 +294,8 @@ public final class PathExecutor {
             harness.clearAllKeys();
             return true;
         }
+        movement.setExecutionDelegate(capabilityGuardedDelegate(
+                harness, context.navigationCapabilities()));
         MovementStatus movementStatus = movement.update();
         if (movementStatus == MovementStatus.UNREACHABLE || movementStatus == MovementStatus.FAILED) {
             Constants.LOG.debug("移动报 {},取消", movementStatus);
@@ -564,7 +566,8 @@ public final class PathExecutor {
                     // 霜行者只在贴地跨过方块边缘时结冰,可能冲过头;下一步
                     // 同向平走/跑酷时强制慢速直进(跑酷且有耗材可放置替代除外)
                     if (next instanceof MovementTraverse || next instanceof MovementParkour) {
-                        boolean couldPlaceInstead = NavSettings.get().allowPlace
+                        boolean couldPlaceInstead = context.canPlace()
+                                && NavSettings.get().allowPlace
                                 && context.hasThrowaway && next instanceof MovementParkour;
                         boolean sameFlatDirection =
                                 !current.getDirection().above().offset(next.getDirection()).equals(BlockPos.ZERO)
@@ -648,6 +651,46 @@ public final class PathExecutor {
             }
         }
         return false;
+    }
+
+    static boolean permitsWorldModificationInput(NavigationCapabilities capabilities, Input input) {
+        return switch (input) {
+            case CLICK_LEFT -> capabilities.allowBreak();
+            case CLICK_RIGHT -> capabilities.allowPlace()
+                    || capabilities.allowWaterBucketLanding();
+            default -> true;
+        };
+    }
+
+    static Movement.ExecutionDelegate capabilityGuardedDelegate(
+            Movement.ExecutionDelegate delegate, NavigationCapabilities capabilities) {
+        java.util.Objects.requireNonNull(delegate, "delegate");
+        java.util.Objects.requireNonNull(capabilities, "capabilities");
+        return new Movement.ExecutionDelegate() {
+            @Override
+            public void beginBreaking(MovementState state, BlockPos pos) {
+                if (capabilities.allowBreak()) {
+                    delegate.beginBreaking(state, pos);
+                }
+            }
+
+            @Override
+            public void applyRotation(MovementState.MovementTarget target) {
+                delegate.applyRotation(target);
+            }
+
+            @Override
+            public void clearInputs() {
+                delegate.clearInputs();
+            }
+
+            @Override
+            public void applyInput(Input input, boolean held) {
+                if (permitsWorldModificationInput(capabilities, input)) {
+                    delegate.applyInput(input, held);
+                }
+            }
+        };
     }
 
     /**

--- a/common/src/main/java/com/dwinovo/numen/core/pathing/moves/CalculationContext.java
+++ b/common/src/main/java/com/dwinovo/numen/core/pathing/moves/CalculationContext.java
@@ -1,6 +1,7 @@
 package com.dwinovo.numen.core.pathing.moves;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.dwinovo.numen.core.pathing.settings.NavSettings;
 import com.dwinovo.numen.core.pathing.util.BlockHelper;
@@ -83,6 +84,7 @@ public class CalculationContext {
     public final double walkOnWaterOnePenalty;
     public final boolean allowPlaceInFluidsSource;
     public final boolean allowPlaceInFluidsFlow;
+    private final NavigationCapabilities navigationCapabilities;
 
     /** 不可挖不可埋的自身目标格(BlockPos.asLong 键),不可穿透。 */
     public final LongSet sacred;
@@ -103,13 +105,30 @@ public class CalculationContext {
     public CalculationContext(ServerPlayer player, BlockGetter view, ChunkLoadedTest loadedTest,
                               boolean safeForThreadedUse) {
         this(player, view, loadedTest, safeForThreadedUse,
-                LongSets.emptySet(), LongSets.emptySet());
+                LongSets.emptySet(), LongSets.emptySet(), NavigationCapabilities.DEFAULT);
+    }
+
+    public CalculationContext(ServerPlayer player, BlockGetter view, ChunkLoadedTest loadedTest,
+                              boolean safeForThreadedUse,
+                              NavigationCapabilities navigationCapabilities) {
+        this(player, view, loadedTest, safeForThreadedUse,
+                LongSets.emptySet(), LongSets.emptySet(), navigationCapabilities);
     }
 
     public CalculationContext(ServerPlayer player, BlockGetter view, ChunkLoadedTest loadedTest,
                               boolean safeForThreadedUse,
                               LongSet sacred, LongSet deniedPlace) {
+        this(player, view, loadedTest, safeForThreadedUse,
+                sacred, deniedPlace, NavigationCapabilities.DEFAULT);
+    }
+
+    public CalculationContext(ServerPlayer player, BlockGetter view, ChunkLoadedTest loadedTest,
+                              boolean safeForThreadedUse,
+                              LongSet sacred, LongSet deniedPlace,
+                              NavigationCapabilities navigationCapabilities) {
         NavSettings settings = NavSettings.get();
+        this.navigationCapabilities = Objects.requireNonNull(
+                navigationCapabilities, "navigationCapabilities");
         this.safeForThreadedUse = safeForThreadedUse;
         this.player = player;
         this.view = view;
@@ -117,14 +136,17 @@ public class CalculationContext {
         this.sacred = sacred;
         this.deniedPlace = deniedPlace;
         this.toolSet = new ToolSet(player);
-        this.hasThrowaway = settings.allowPlace && hasGenericThrowaway(player, settings);
-        this.hasWaterBucket = settings.allowWaterBucketFall
+        this.hasThrowaway = navigationCapabilities.permitsPlace(settings.allowPlace)
+                && hasGenericThrowaway(player, settings);
+        this.hasWaterBucket = navigationCapabilities.permitsWaterBucketLanding(
+                settings.allowWaterBucketFall)
                 && hotbarHasWaterBucket(player)
                 && player.level().dimension() != Level.NETHER;
         this.canSprint = settings.allowSprint && player.getFoodData().getFoodLevel() > 6;
         this.placeBlockCost = settings.blockPlacementPenalty;
-        this.allowBreak = settings.allowBreak;
-        this.allowBreakAnyway = List.copyOf(settings.allowBreakAnyway());
+        this.allowBreak = navigationCapabilities.permitsBreak(settings.allowBreak);
+        this.allowBreakAnyway = navigationCapabilities.permittedBreakExceptions(
+                settings.allowBreakAnyway());
         this.allowParkour = settings.allowParkour;
         this.allowParkourPlace = settings.allowParkourPlace;
         this.allowJumpAtBuildLimit = settings.allowJumpAtBuildLimit;
@@ -253,7 +275,7 @@ public class CalculationContext {
      * 否则放置罚金。
      */
     public double costOfPlacingAt(int x, int y, int z, BlockState current) {
-        if (!hasThrowaway) { // 构造时已含 allowPlace 判定
+        if (!canPlace() || !hasThrowaway) { // 构造时已含全局 allowPlace 判定
             return COST_INF;
         }
         long key = BlockPos.asLong(x, y, z);
@@ -289,6 +311,9 @@ public class CalculationContext {
      * 在 {@code getStrVsBlock} 里实现,此处不参与。
      */
     public double breakCostMultiplierAt(int x, int y, int z, BlockState current) {
+        if (!canBreak()) {
+            return COST_INF;
+        }
         if (sacred.contains(BlockPos.asLong(x, y, z))) {
             return COST_INF;
         }
@@ -303,6 +328,25 @@ public class CalculationContext {
 
     /** 坠落中放水桶的成本(与放置罚金同价)。 */
     public double placeBucketCost() {
-        return placeBlockCost;
+        return canUseWaterBucketLanding() ? placeBlockCost : COST_INF;
+    }
+
+    public NavigationCapabilities navigationCapabilities() {
+        return navigationCapabilities;
+    }
+
+    /** 本次导航是否允许走破坏链；全局设置仍由 allowBreak/例外快照收窄。 */
+    public boolean canBreak() {
+        return navigationCapabilities.allowBreak();
+    }
+
+    /** 本次导航是否允许走放置链；全局设置和库存仍由 hasThrowaway 收窄。 */
+    public boolean canPlace() {
+        return navigationCapabilities.allowPlace();
+    }
+
+    /** 本次导航是否允许走水桶落地链；全局设置和库存仍由 hasWaterBucket 收窄。 */
+    public boolean canUseWaterBucketLanding() {
+        return navigationCapabilities.allowWaterBucketLanding();
     }
 }

--- a/common/src/main/java/com/dwinovo/numen/core/pathing/moves/Moves.java
+++ b/common/src/main/java/com/dwinovo/numen/core/pathing/moves/Moves.java
@@ -358,6 +358,7 @@ public enum Moves {
         if (res.cost >= ActionCosts.COST_INF) {
             return null;
         }
-        return new MovementParkour(context.player, src, new BlockPos(res.x, res.y, res.z));
+        return new MovementParkour(context.player, src, new BlockPos(res.x, res.y, res.z),
+                context.navigationCapabilities());
     }
 }

--- a/common/src/main/java/com/dwinovo/numen/core/pathing/moves/NavigationCapabilities.java
+++ b/common/src/main/java/com/dwinovo/numen/core/pathing/moves/NavigationCapabilities.java
@@ -1,0 +1,43 @@
+package com.dwinovo.numen.core.pathing.moves;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 一次导航允许使用的世界修改能力。能力随 {@link CalculationContext}
+ * 传递，不修改全局设置，也不保存到世界数据。
+ */
+public record NavigationCapabilities(
+        boolean allowBreak,
+        boolean allowPlace,
+        boolean allowWaterBucketLanding) {
+
+    /** 现有导航的兼容预设：保留全局设置原有行为。 */
+    public static final NavigationCapabilities DEFAULT =
+            new NavigationCapabilities(true, true, true);
+
+    /** 自动跟随的硬限制预设：不允许任何主动世界修改。 */
+    public static final NavigationCapabilities SAFE_FOLLOW =
+            new NavigationCapabilities(false, false, false);
+
+    public boolean permitsBreak(boolean configured) {
+        return allowBreak && configured;
+    }
+
+    public boolean permitsPlace(boolean configured) {
+        return allowPlace && configured;
+    }
+
+    public boolean permitsWaterBucketLanding(boolean configured) {
+        return allowWaterBucketLanding && configured;
+    }
+
+    /**
+     * 导航禁止破坏时，连全局 allowBreakAnyway 例外也必须清空。
+     * 默认能力仍返回配置的不可变快照。
+     */
+    public <T> List<T> permittedBreakExceptions(List<T> configured) {
+        Objects.requireNonNull(configured, "configured");
+        return allowBreak ? List.copyOf(configured) : List.of();
+    }
+}

--- a/common/src/main/java/com/dwinovo/numen/core/pathing/moves/movements/MovementParkour.java
+++ b/common/src/main/java/com/dwinovo/numen/core/pathing/moves/movements/MovementParkour.java
@@ -10,6 +10,7 @@ import com.dwinovo.numen.core.pathing.moves.MovementHelper;
 import com.dwinovo.numen.core.pathing.moves.MovementState;
 import com.dwinovo.numen.core.pathing.moves.MovementStatus;
 import com.dwinovo.numen.core.pathing.moves.MutableMoveResult;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
 import com.dwinovo.numen.core.pathing.settings.NavSettings;
 
 import net.minecraft.core.BlockPos;
@@ -33,9 +34,17 @@ public class MovementParkour extends Movement {
     private final Direction direction;
     private final int dist;
     private final boolean ascend;
+    private final NavigationCapabilities navigationCapabilities;
 
     public MovementParkour(ServerPlayer player, BlockPos src, BlockPos dest) {
+        this(player, src, dest, NavigationCapabilities.DEFAULT);
+    }
+
+    public MovementParkour(ServerPlayer player, BlockPos src, BlockPos dest,
+                           NavigationCapabilities navigationCapabilities) {
         super(player, src, dest, EMPTY, dest.below());
+        this.navigationCapabilities = java.util.Objects.requireNonNull(
+                navigationCapabilities, "navigationCapabilities");
         int dx = dest.getX() - src.getX();
         int dz = dest.getZ() - src.getZ();
         this.direction = Direction.getNearest(dx, 0, dz);
@@ -267,7 +276,7 @@ public class MovementParkour extends Movement {
         } else if (!feet.equals(src)) {
             if (feet.equals(src.relative(direction)) || player.getY() - src.getY() > 0.0001) {
                 // 已跳出第一格或已离地
-                if (NavSettings.get().allowPlace
+                if (navigationCapabilities.permitsPlace(NavSettings.get().allowPlace)
                         && MovementPlacement.selectForLocation(player, dest.below(), false)
                         && !MovementHelper.canWalkOn(player.level(), dest.below())
                         && !player.onGround()
@@ -299,4 +308,3 @@ public class MovementParkour extends Movement {
         return state;
     }
 }
-

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowCommandsTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowCommandsTest.java
@@ -1,0 +1,151 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.mojang.brigadier.CommandDispatcher;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+
+class FollowCommandsTest {
+
+    @Test
+    void commandTreeUsesExistingNumenRootAndExactFollowShape() {
+        CommandDispatcher<CommandSourceStack> dispatcher =
+                new CommandDispatcher<>();
+        dispatcher.register(Commands.literal("numen")
+                .then(Commands.literal("existing")));
+
+        FollowCommands.register(dispatcher, FollowConfig.defaults());
+
+        var numen = dispatcher.getRoot().getChild("numen");
+        assertTrue(numen.getChild("existing") != null);
+        var follow = numen.getChild("follow");
+        assertTrue(follow != null);
+        var name = follow.getChild(FollowCommands.COMPANION_ARGUMENT);
+        assertTrue(name != null);
+        assertEquals(1, name.getChildren().size());
+        assertTrue(name.getChild(FollowCommands.ACTION_ARGUMENT) != null);
+    }
+
+    @ParameterizedTest
+    @EnumSource(FollowAction.class)
+    void commandActionUsesTheSharedCaseInsensitiveParser(FollowAction action) {
+        assertEquals(action,
+                FollowAction.parse(action.name()).orElseThrow());
+        assertEquals(action,
+                FollowAction.parse(action.argumentValue()).orElseThrow());
+    }
+
+    @Test
+    void ownerCanResolveOnlyTheirExactOnlineCompanionName() {
+        UUID owner = UUID.randomUUID();
+        Candidate mine = new Candidate("Alpha", owner);
+        Candidate theirs = new Candidate("Alpha", UUID.randomUUID());
+
+        FollowCommands.Resolution<Candidate> result =
+                resolve(List.of(theirs, mine), owner, "Alpha");
+
+        assertEquals(FollowCommands.ResolutionCode.FOUND, result.code());
+        assertSame(mine, result.value());
+    }
+
+    @Test
+    void otherOwnersCompanionIsRejected() {
+        UUID owner = UUID.randomUUID();
+        Candidate theirs = new Candidate("Alpha", UUID.randomUUID());
+
+        FollowCommands.Resolution<Candidate> result =
+                resolve(List.of(theirs), owner, "Alpha");
+
+        assertEquals(FollowCommands.ResolutionCode.NOT_FOUND, result.code());
+        assertNull(result.value());
+    }
+
+    @Test
+    void missingCompanionIsRejectedWithoutChoosingAFirstCompanion() {
+        UUID owner = UUID.randomUUID();
+        Candidate available = new Candidate("Beta", owner);
+
+        FollowCommands.Resolution<Candidate> result =
+                resolve(List.of(available), owner, "Missing");
+
+        assertEquals(FollowCommands.ResolutionCode.NOT_FOUND, result.code());
+    }
+
+    @Test
+    void multipleOwnedCompanionsAreResolvedByExplicitName() {
+        UUID owner = UUID.randomUUID();
+        Candidate alpha = new Candidate("Alpha", owner);
+        Candidate beta = new Candidate("Beta", owner);
+
+        assertSame(alpha,
+                resolve(List.of(alpha, beta), owner, "Alpha").value());
+        assertSame(beta,
+                resolve(List.of(alpha, beta), owner, "Beta").value());
+    }
+
+    @Test
+    void duplicateOwnedNamesAreRejectedAsAmbiguous() {
+        UUID owner = UUID.randomUUID();
+
+        FollowCommands.Resolution<Candidate> result = resolve(
+                List.of(
+                        new Candidate("Alpha", owner),
+                        new Candidate("Alpha", owner)),
+                owner,
+                "Alpha");
+
+        assertEquals(FollowCommands.ResolutionCode.AMBIGUOUS, result.code());
+        assertNull(result.value());
+    }
+
+    @Test
+    void allAndUuidTextCannotBypassExplicitHumanName() {
+        UUID owner = UUID.randomUUID();
+        UUID companionUuid = UUID.randomUUID();
+        Candidate candidate = new Candidate(companionUuid.toString(), owner);
+
+        assertEquals(FollowCommands.ResolutionCode.INVALID_NAME,
+                resolve(List.of(candidate), owner, "all").code());
+        assertEquals(FollowCommands.ResolutionCode.INVALID_NAME,
+                resolve(List.of(candidate), owner, companionUuid.toString()).code());
+    }
+
+    @Test
+    void emptyNameIsRejected() {
+        assertEquals(FollowCommands.ResolutionCode.INVALID_NAME,
+                resolve(List.of(), UUID.randomUUID(), " ").code());
+    }
+
+    @Test
+    void nameResolutionNeverFallsBackToRecentOrCaseInsensitivePlayer() {
+        UUID owner = UUID.randomUUID();
+        Candidate candidate = new Candidate("Alpha", owner);
+
+        assertEquals(FollowCommands.ResolutionCode.NOT_FOUND,
+                resolve(List.of(candidate), owner, "alpha").code());
+    }
+
+    private static FollowCommands.Resolution<Candidate> resolve(
+            List<Candidate> online, UUID owner, String requested) {
+        return FollowCommands.resolveOwnedByName(
+                online,
+                owner,
+                requested,
+                Candidate::name,
+                Candidate::ownerUuid);
+    }
+
+    private record Candidate(String name, UUID ownerUuid) {}
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowConfigIntegrationTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowConfigIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.nbt.CompoundTag;
+
+class FollowConfigIntegrationTest {
+
+    private static final FollowConfig CUSTOM = new FollowConfig(
+            2.0, 4.0, 9.0, 20.0, 50.0, 240L,
+            false, false, false, false, false);
+
+    @Test
+    void defaultConfigurationPreservesStageFourThresholds() {
+        FollowConfig config = FollowConfig.defaults();
+
+        assertEquals(new FollowDecisions.Distances(3.0, 5.5),
+                FollowDecisions.resolveDistances(null, null, config));
+        assertFalse(decide(config, 11.99, false).sprintAllowed());
+        assertTrue(decide(config, 12.0, false).sprintAllowed());
+        assertFalse(decide(config, 23.99, false).catchingUp());
+        assertTrue(decide(config, 24.0, false).catchingUp());
+    }
+
+    @Test
+    void customStopAndStartDriveHysteresis() {
+        assertEquals(FollowRuntimeState.IDLE_NEAR_OWNER,
+                decide(CUSTOM, 2.0, false).runtimeState());
+        assertEquals(FollowRuntimeState.IDLE_NEAR_OWNER,
+                decide(CUSTOM, 3.99, false).runtimeState());
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                decide(CUSTOM, 4.0, false).runtimeState());
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                decide(CUSTOM, 3.0, true).runtimeState());
+    }
+
+    @Test
+    void customSprintCatchUpAndLostBoundariesApply() {
+        assertFalse(decide(CUSTOM, 8.99, false).sprintAllowed());
+        assertTrue(decide(CUSTOM, 9.0, false).sprintAllowed());
+        assertFalse(decide(CUSTOM, 19.99, false).catchingUp());
+        assertTrue(decide(CUSTOM, 20.0, false).catchingUp());
+        assertEquals(FollowWaitingReason.OWNER_TOO_FAR,
+                decide(CUSTOM, 50.0, true).waitingReason());
+    }
+
+    @Test
+    void customFailureCooldownIsExact() {
+        FollowDecisions.Result active = decide(CUSTOM, 8.0, false);
+
+        FollowDecisions.Result failed =
+                FollowDecisions.failedAt(active, 10L, CUSTOM);
+
+        assertEquals(250L, failed.failedUntilTick());
+        assertEquals(240L, FollowDecisions.remainingCooldownTicks(
+                failed.failedUntilTick(), 10L));
+    }
+
+    @Test
+    void validCompanionOverrideWinsOverConfiguration() {
+        assertEquals(new FollowDecisions.Distances(2.5, 6.5),
+                FollowDecisions.resolveDistances(2.5, 6.5, CUSTOM));
+    }
+
+    @Test
+    void overrideStartMustRemainBelowEffectiveSprint() {
+        assertEquals(new FollowDecisions.Distances(2.0, 4.0),
+                FollowDecisions.resolveDistances(2.5, 9.0, CUSTOM));
+    }
+
+    @Test
+    void everyInvalidOverrideFallsBackAsOnePair() {
+        assertEquals(new FollowDecisions.Distances(2.0, 4.0),
+                FollowDecisions.resolveDistances(null, 6.0, CUSTOM));
+        assertEquals(new FollowDecisions.Distances(2.0, 4.0),
+                FollowDecisions.resolveDistances(6.0, 5.0, CUSTOM));
+        assertEquals(new FollowDecisions.Distances(2.0, 4.0),
+                FollowDecisions.resolveDistances(Double.NaN, 5.0, CUSTOM));
+    }
+
+    @Test
+    void chainCapturesExactImmutableConfigurationInstance() {
+        OwnerFollowChainTestHarness first =
+                new OwnerFollowChainTestHarness(
+                        OwnerFollowChainTestHarness.activeAt(6.0, 1L), CUSTOM);
+        OwnerFollowChainTestHarness second =
+                new OwnerFollowChainTestHarness(
+                        OwnerFollowChainTestHarness.activeAt(6.0, 1L), CUSTOM);
+
+        assertSame(CUSTOM, first.chain.config());
+        assertSame(CUSTOM, second.chain.config());
+        first.chain.tick(null);
+        assertTrue(first.chain.hasNavigation());
+        assertFalse(second.chain.hasNavigation());
+    }
+
+    @Test
+    void chainUsesCapturedConfigWithoutReloadingAFile() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(
+                        OwnerFollowChainTestHarness.activeAt(4.0, 1L), CUSTOM);
+
+        harness.chain.tick(null);
+        harness.access.snapshot = OwnerFollowChainTestHarness.activeAt(8.99, 2L);
+        harness.chain.tick(null);
+
+        assertFalse(harness.chain.runtimeView().sprintAllowed());
+        assertSame(CUSTOM, harness.chain.config());
+    }
+
+    @Test
+    void configurationNeverEntersFollowStateNbt() {
+        FollowStateStore store = new FollowStateStore();
+        store.put(UUID.randomUUID(), new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, 2.5, 6.5));
+
+        String nbt = store.save(new CompoundTag()).toString();
+
+        assertFalse(nbt.contains("sprint"));
+        assertFalse(nbt.contains("catch"));
+        assertFalse(nbt.contains("lost"));
+        assertFalse(nbt.contains("cooldown"));
+        assertFalse(nbt.contains("allow"));
+    }
+
+    private static FollowDecisions.Result decide(
+            FollowConfig config, double distance, boolean following) {
+        return FollowDecisions.decide(
+                new FollowDecisions.Input(
+                        true, false, true, true, true, true, true,
+                        distance, null, null, 10L),
+                following,
+                FollowDecisions.NO_FAILED_COOLDOWN,
+                config);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowConfigTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowConfigTest.java
@@ -1,0 +1,283 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+class FollowConfigTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void defaultsAreExactAndAllWorldChangingCapabilitiesAreOff() {
+        assertDefaults(FollowConfig.defaults());
+    }
+
+    @Test
+    void missingFileUsesDefaultsAndWritesCanonicalFile() throws IOException {
+        Path file = tempDir.resolve("numen").resolve("auto_follow.json");
+
+        FollowConfig loaded = FollowConfig.load(file);
+
+        assertDefaults(loaded);
+        assertTrue(Files.isRegularFile(file));
+        JsonObject json = JsonParser.parseString(
+                Files.readString(file, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertEquals(Set.of(
+                "stop_distance",
+                "start_distance",
+                "sprint_distance",
+                "catch_up_distance",
+                "lost_distance",
+                "failed_cooldown_ticks",
+                "allow_break",
+                "allow_place",
+                "allow_water_bucket_landing",
+                "allow_teleport",
+                "allow_cross_dimension"), json.keySet());
+    }
+
+    @Test
+    void creationFailureDoesNotPreventInMemoryDefaults() throws IOException {
+        Path parentFile = tempDir.resolve("not-a-directory");
+        Files.writeString(parentFile, "occupied", StandardCharsets.UTF_8);
+
+        FollowConfig loaded =
+                FollowConfig.load(parentFile.resolve("auto_follow.json"));
+
+        assertDefaults(loaded);
+    }
+
+    @Test
+    void validCompleteConfigurationLoads() throws IOException {
+        Path file = write(validJson(2.0, 4.0, 9.0, 20.0, 50.0, "240"));
+
+        FollowConfig config = FollowConfig.load(file);
+
+        assertEquals(2.0, config.stopDistance());
+        assertEquals(4.0, config.startDistance());
+        assertEquals(9.0, config.sprintDistance());
+        assertEquals(20.0, config.catchUpDistance());
+        assertEquals(50.0, config.lostDistance());
+        assertEquals(240L, config.failedCooldownTicks());
+    }
+
+    @Test
+    void missingNumericFieldsUseDefaultsBeforeValidation() throws IOException {
+        Path file = write("{\"stop_distance\":2.0,\"start_distance\":4.0}");
+
+        FollowConfig config = FollowConfig.load(file);
+
+        assertEquals(2.0, config.stopDistance());
+        assertEquals(4.0, config.startDistance());
+        assertEquals(12.0, config.sprintDistance());
+        assertEquals(100L, config.failedCooldownTicks());
+    }
+
+    @Test
+    void unknownFieldsAreIgnored() throws IOException {
+        String json = validJson(2.0, 4.0, 9.0, 20.0, 50.0, "240")
+                .replaceFirst("\\}$", ",\"future_field\":{\"x\":1}}");
+
+        FollowConfig config = FollowConfig.load(write(json));
+
+        assertEquals(2.0, config.stopDistance());
+        assertEquals(240L, config.failedCooldownTicks());
+    }
+
+    @Test
+    void damagedJsonFallsBackToAllNumericDefaults() throws IOException {
+        assertDefaults(FollowConfig.load(write("{not-json")));
+    }
+
+    @Test
+    void nonObjectRootFallsBackToAllNumericDefaults() throws IOException {
+        assertDefaults(FollowConfig.load(write("[1,2,3]")));
+    }
+
+    @Test
+    void knownFieldTypeErrorFallsBackToAllNumericDefaults() throws IOException {
+        JsonObject root = JsonParser.parseString(
+                validJson(2.0, 4.0, 9.0, 20.0, 50.0, "240")).getAsJsonObject();
+        root.addProperty("stop_distance", "two");
+
+        assertDefaults(FollowConfig.load(write(root.toString())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"NaN", "Infinity", "0", "-1"})
+    void nonFiniteOrNonPositiveDistanceFallsBackToAllDefaults(String token)
+            throws IOException {
+        assertDefaults(FollowConfig.load(write(
+                validJsonRaw(token, "4.0", "9.0", "20.0", "50.0", "240"))));
+    }
+
+    @Test
+    void stopAtOrAboveStartFallsBackToDefaults() throws IOException {
+        assertDefaults(FollowConfig.load(write(
+                validJson(4.0, 4.0, 9.0, 20.0, 50.0, "240"))));
+    }
+
+    @Test
+    void startAtOrAboveSprintFallsBackToDefaults() throws IOException {
+        assertDefaults(FollowConfig.load(write(
+                validJson(2.0, 9.0, 9.0, 20.0, 50.0, "240"))));
+    }
+
+    @Test
+    void sprintAboveCatchUpFallsBackToDefaults() throws IOException {
+        assertDefaults(FollowConfig.load(write(
+                validJson(2.0, 4.0, 21.0, 20.0, 50.0, "240"))));
+    }
+
+    @Test
+    void catchUpAtLostFallsBackToDefaults() throws IOException {
+        assertDefaults(FollowConfig.load(write(
+                validJson(2.0, 4.0, 9.0, 50.0, 50.0, "240"))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.5", "0", "-1", "2147483648"})
+    void invalidCooldownFallsBackToAllDefaults(String token) throws IOException {
+        assertDefaults(FollowConfig.load(write(
+                validJson(2.0, 4.0, 9.0, 20.0, 50.0, token))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "allow_break",
+            "allow_place",
+            "allow_water_bucket_landing",
+            "allow_teleport",
+            "allow_cross_dimension"
+    })
+    void requestedUnsafeCapabilityStaysFalseWithoutDiscardingValidNumbers(
+            String field) throws IOException {
+        String json = validJson(2.0, 4.0, 9.0, 20.0, 50.0, "240")
+                .replaceFirst("\\}$", ",\"" + field + "\":true}");
+
+        FollowConfig config = FollowConfig.load(write(json));
+
+        assertEquals(2.0, config.stopDistance());
+        assertEquals(240L, config.failedCooldownTicks());
+        assertAllCapabilitiesFalse(config);
+    }
+
+    @Test
+    void invalidExistingFileIsNeverOverwritten() throws IOException {
+        Path file = write("{broken-user-content");
+        String before = Files.readString(file, StandardCharsets.UTF_8);
+
+        FollowConfig.load(file);
+
+        assertEquals(before, Files.readString(file, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void separateLoadCallsDoNotCreateMutableGlobalConfiguration() throws IOException {
+        Path first = tempDir.resolve("first.json");
+        Path second = tempDir.resolve("second.json");
+        Files.writeString(first,
+                validJson(2.0, 4.0, 9.0, 20.0, 50.0, "200"),
+                StandardCharsets.UTF_8);
+        Files.writeString(second,
+                validJson(2.5, 4.5, 10.0, 21.0, 51.0, "201"),
+                StandardCharsets.UTF_8);
+
+        FollowConfig firstConfig = FollowConfig.load(first);
+        FollowConfig secondConfig = FollowConfig.load(second);
+
+        assertEquals(2.0, firstConfig.stopDistance());
+        assertEquals(2.5, secondConfig.stopDistance());
+        assertNotEquals(firstConfig, secondConfig);
+    }
+
+    @Test
+    void publicConstructionAlsoClampsUnsafeFlagsAndInvalidNumbers() {
+        FollowConfig config = new FollowConfig(
+                -1.0, 1.0, 1.0, 1.0, 1.0, -1L,
+                true, true, true, true, true);
+
+        assertDefaults(config);
+    }
+
+    private Path write(String json) throws IOException {
+        Path file = tempDir.resolve("auto_follow-" + System.nanoTime() + ".json");
+        Files.writeString(file, json, StandardCharsets.UTF_8);
+        return file;
+    }
+
+    private static String validJson(
+            double stop,
+            double start,
+            double sprint,
+            double catchUp,
+            double lost,
+            String cooldown) {
+        return validJsonRaw(
+                Double.toString(stop),
+                Double.toString(start),
+                Double.toString(sprint),
+                Double.toString(catchUp),
+                Double.toString(lost),
+                cooldown);
+    }
+
+    private static String validJsonRaw(
+            String stop,
+            String start,
+            String sprint,
+            String catchUp,
+            String lost,
+            String cooldown) {
+        return """
+                {
+                  "stop_distance": %s,
+                  "start_distance": %s,
+                  "sprint_distance": %s,
+                  "catch_up_distance": %s,
+                  "lost_distance": %s,
+                  "failed_cooldown_ticks": %s,
+                  "allow_break": false,
+                  "allow_place": false,
+                  "allow_water_bucket_landing": false,
+                  "allow_teleport": false,
+                  "allow_cross_dimension": false
+                }
+                """.formatted(stop, start, sprint, catchUp, lost, cooldown);
+    }
+
+    private static void assertDefaults(FollowConfig config) {
+        assertEquals(3.0, config.stopDistance());
+        assertEquals(5.5, config.startDistance());
+        assertEquals(12.0, config.sprintDistance());
+        assertEquals(24.0, config.catchUpDistance());
+        assertEquals(64.0, config.lostDistance());
+        assertEquals(100L, config.failedCooldownTicks());
+        assertAllCapabilitiesFalse(config);
+    }
+
+    private static void assertAllCapabilitiesFalse(FollowConfig config) {
+        assertFalse(config.allowBreak());
+        assertFalse(config.allowPlace());
+        assertFalse(config.allowWaterBucketLanding());
+        assertFalse(config.allowTeleport());
+        assertFalse(config.allowCrossDimension());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowConfiguredCooldownTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowConfiguredCooldownTest.java
@@ -1,0 +1,117 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+
+class FollowConfiguredCooldownTest {
+
+    private static final FollowConfig CUSTOM = new FollowConfig(
+            2.0, 4.0, 9.0, 20.0, 50.0, 240L,
+            false, false, false, false, false);
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("configs")
+    void configuredDeadlineHasExactRetryBoundary(
+            String name, FollowConfig config) {
+        long failureTick = 500L;
+        FollowDecisions.Result active = decide(
+                config, config.startDistance(), failureTick,
+                FollowDecisions.NO_FAILED_COOLDOWN);
+
+        FollowDecisions.Result failed =
+                FollowDecisions.failedAt(active, failureTick, config);
+        long deadline = failureTick + config.failedCooldownTicks();
+        FollowDecisions.Result before = decide(
+                config, config.startDistance(), deadline - 1L, deadline);
+        FollowDecisions.Result exact = decide(
+                config, config.startDistance(), deadline, deadline);
+        FollowDecisions.Result after = decide(
+                config, config.startDistance(), deadline + 1L, deadline);
+
+        assertEquals(deadline, failed.failedUntilTick(), name);
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN,
+                before.runtimeState(), name);
+        assertEquals(1L, FollowDecisions.remainingCooldownTicks(
+                deadline, deadline - 1L), name);
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                exact.runtimeState(), name);
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                after.runtimeState(), name);
+        assertEquals(0L, FollowDecisions.remainingCooldownTicks(
+                deadline, deadline), name);
+        assertEquals(0L, FollowDecisions.remainingCooldownTicks(
+                deadline, deadline + 1L), name);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FollowReleaseReason.class,
+            names = {"FOLLOW_DISABLED", "MANUAL_PAUSE"})
+    void offAndPauseReleaseClearExistingFailureDeadline(
+            FollowReleaseReason reason) {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 50L));
+        harness.factory.nextStatus = PlayerNav.Status.FAILED;
+        harness.chain.tick(null);
+        assertEquals(150L, harness.chain.runtimeView().failedUntilTick());
+
+        harness.chain.release(reason);
+
+        FollowRuntimeSnapshot snapshot = harness.chain.runtimeView();
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                snapshot.failedUntilTick());
+        assertEquals(0L, snapshot.remainingCooldownTicks());
+        assertFalse(snapshot.following());
+        assertFalse(snapshot.navigationActive());
+        if (reason == FollowReleaseReason.FOLLOW_DISABLED) {
+            assertEquals(FollowRuntimeState.DISABLED, snapshot.runtimeState());
+        } else {
+            assertEquals(FollowRuntimeState.MANUALLY_PAUSED,
+                    snapshot.runtimeState());
+        }
+    }
+
+    @Test
+    void threeDimensionalDistanceCanLandExactlyOnConfiguredBoundary() {
+        double distance = FollowDecisions.distance3d(
+                0.0, 0.0, 0.0, 0.0, CUSTOM.startDistance(), 0.0);
+
+        FollowDecisions.Result result = decide(
+                CUSTOM, distance, 10L, FollowDecisions.NO_FAILED_COOLDOWN);
+
+        assertEquals(CUSTOM.startDistance(), distance);
+        assertEquals(FollowRuntimeState.FOLLOWING, result.runtimeState());
+        assertTrue(result.following());
+    }
+
+    private static Stream<Arguments> configs() {
+        return Stream.of(
+                Arguments.of("default", FollowConfig.defaults()),
+                Arguments.of("custom", CUSTOM));
+    }
+
+    private static FollowDecisions.Result decide(
+            FollowConfig config,
+            double distance,
+            long currentTick,
+            long failedUntilTick) {
+        return FollowDecisions.decide(
+                new FollowDecisions.Input(
+                        true, false, true, true, true, true, true,
+                        distance, null, null, currentTick),
+                true,
+                failedUntilTick,
+                config);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowContextProviderTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowContextProviderTest.java
@@ -1,0 +1,31 @@
+package com.dwinovo.numen.core.follow;
+
+import com.dwinovo.numen.core.pathing.bridge.ContextFactory;
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class FollowContextProviderTest {
+
+    @Test
+    void providerImplementsPlayerNavContractWithSafeCapabilities() {
+        PlayerNav.ContextProvider provider = FollowContextProvider.INSTANCE;
+
+        assertNotNull(provider);
+        assertSame(NavigationCapabilities.SAFE_FOLLOW,
+                FollowContextProvider.capabilities());
+    }
+
+    @Test
+    void searchAndExecutionShareOneImmutableContextBuilder() {
+        ContextFactory.ContextBuilder first = FollowContextProvider.contextBuilder();
+        ContextFactory.ContextBuilder second = FollowContextProvider.contextBuilder();
+
+        assertNotNull(first);
+        assertSame(first, second);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowDecisionBoundaryMatrixTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowDecisionBoundaryMatrixTest.java
@@ -1,0 +1,244 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FollowDecisionBoundaryMatrixTest {
+
+    private static final double EPSILON = 1.0e-6;
+    private static final FollowConfig DEFAULT = FollowConfig.defaults();
+    private static final FollowConfig CUSTOM = new FollowConfig(
+            2.0, 4.0, 9.0, 20.0, 50.0, 240L,
+            false, false, false, false, false);
+
+    @ParameterizedTest(name = "{0} {1}")
+    @MethodSource("exactBoundaryCases")
+    void exactThresholdAndBothSidesUseApprovedComparisons(
+            String configName,
+            String boundary,
+            FollowConfig config,
+            double distance,
+            FollowRuntimeState expectedState,
+            FollowWaitingReason expectedReason,
+            boolean expectedFollowing,
+            boolean expectedSprint,
+            boolean expectedCatchUp) {
+        FollowDecisions.Result result = decide(config, distance, false);
+
+        assertEquals(expectedState, result.runtimeState(),
+                configName + " " + boundary);
+        assertEquals(expectedReason, result.waitingReason(),
+                configName + " " + boundary);
+        assertEquals(expectedFollowing, result.following(),
+                configName + " " + boundary);
+        assertEquals(expectedSprint, result.sprintAllowed(),
+                configName + " " + boundary);
+        assertEquals(expectedCatchUp, result.catchingUp(),
+                configName + " " + boundary);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("configs")
+    void hysteresisBandPreservesBothClosedAndOpenLatch(
+            String configName, FollowConfig config) {
+        double midpoint = (config.stopDistance() + config.startDistance()) / 2.0;
+
+        FollowDecisions.Result closed = decide(config, midpoint, false);
+        FollowDecisions.Result open = decide(config, midpoint, true);
+
+        assertEquals(FollowRuntimeState.IDLE_NEAR_OWNER,
+                closed.runtimeState(), configName);
+        assertFalse(closed.following(), configName);
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                open.runtimeState(), configName);
+        assertTrue(open.following(), configName);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidCustomOverrides")
+    void everyInvalidOverrideFallsBackAsOnePair(
+            String label, Double stopOverride, Double startOverride) {
+        FollowDecisions.Distances distances =
+                FollowDecisions.resolveDistances(
+                        stopOverride, startOverride, CUSTOM);
+
+        assertEquals(
+                new FollowDecisions.Distances(
+                        CUSTOM.stopDistance(), CUSTOM.startDistance()),
+                distances,
+                label);
+    }
+
+    @Test
+    void validOverrideChangesOnlyStopAndStart() {
+        FollowDecisions.Distances override =
+                FollowDecisions.resolveDistances(2.5, 6.5, CUSTOM);
+        FollowDecisions.Result beforeSprint = decide(
+                CUSTOM, 8.999999, false, 2.5, 6.5);
+        FollowDecisions.Result atSprint = decide(
+                CUSTOM, 9.0, false, 2.5, 6.5);
+        FollowDecisions.Result atCatchUp = decide(
+                CUSTOM, 20.0, false, 2.5, 6.5);
+        FollowDecisions.Result atLost = decide(
+                CUSTOM, 50.0, true, 2.5, 6.5);
+        FollowDecisions.Result failed =
+                FollowDecisions.failedAt(atSprint, 10L, CUSTOM);
+
+        assertEquals(new FollowDecisions.Distances(2.5, 6.5), override);
+        assertFalse(beforeSprint.sprintAllowed());
+        assertTrue(atSprint.sprintAllowed());
+        assertTrue(atCatchUp.catchingUp());
+        assertEquals(FollowWaitingReason.OWNER_TOO_FAR,
+                atLost.waitingReason());
+        assertEquals(250L, failed.failedUntilTick());
+    }
+
+    @Test
+    void overrideCanBeLegalForDefaultButIllegalForCustomSprint() {
+        FollowDecisions.Distances acceptedByDefault =
+                FollowDecisions.resolveDistances(4.0, 10.0, DEFAULT);
+        FollowDecisions.Distances rejectedByCustom =
+                FollowDecisions.resolveDistances(4.0, 10.0, CUSTOM);
+
+        assertEquals(new FollowDecisions.Distances(4.0, 10.0),
+                acceptedByDefault);
+        assertEquals(new FollowDecisions.Distances(2.0, 4.0),
+                rejectedByCustom);
+    }
+
+    private static Stream<Arguments> exactBoundaryCases() {
+        return Stream.concat(
+                boundaryCases("default", DEFAULT),
+                boundaryCases("custom", CUSTOM));
+    }
+
+    private static Stream<Arguments> boundaryCases(
+            String name, FollowConfig config) {
+        return Stream.of(
+                boundary(name, "stop-epsilon", config,
+                        config.stopDistance() - EPSILON,
+                        FollowRuntimeState.IDLE_NEAR_OWNER,
+                        FollowWaitingReason.NONE, false, false, false),
+                boundary(name, "stop", config,
+                        config.stopDistance(),
+                        FollowRuntimeState.IDLE_NEAR_OWNER,
+                        FollowWaitingReason.NONE, false, false, false),
+                boundary(name, "stop+epsilon", config,
+                        config.stopDistance() + EPSILON,
+                        FollowRuntimeState.IDLE_NEAR_OWNER,
+                        FollowWaitingReason.NONE, false, false, false),
+                boundary(name, "start-epsilon", config,
+                        config.startDistance() - EPSILON,
+                        FollowRuntimeState.IDLE_NEAR_OWNER,
+                        FollowWaitingReason.NONE, false, false, false),
+                boundary(name, "start", config,
+                        config.startDistance(),
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, false, false),
+                boundary(name, "start+epsilon", config,
+                        config.startDistance() + EPSILON,
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, false, false),
+                boundary(name, "sprint-epsilon", config,
+                        config.sprintDistance() - EPSILON,
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, false, false),
+                boundary(name, "sprint", config,
+                        config.sprintDistance(),
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, true, false),
+                boundary(name, "sprint+epsilon", config,
+                        config.sprintDistance() + EPSILON,
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, true, false),
+                boundary(name, "catch-up-epsilon", config,
+                        config.catchUpDistance() - EPSILON,
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, true, false),
+                boundary(name, "catch-up", config,
+                        config.catchUpDistance(),
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, true, true),
+                boundary(name, "catch-up+epsilon", config,
+                        config.catchUpDistance() + EPSILON,
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, true, true),
+                boundary(name, "lost-epsilon", config,
+                        config.lostDistance() - EPSILON,
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE, true, true, true),
+                boundary(name, "lost", config,
+                        config.lostDistance(),
+                        FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.OWNER_TOO_FAR,
+                        false, false, false),
+                boundary(name, "lost+epsilon", config,
+                        config.lostDistance() + EPSILON,
+                        FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.OWNER_TOO_FAR,
+                        false, false, false));
+    }
+
+    private static Arguments boundary(
+            String name,
+            String boundary,
+            FollowConfig config,
+            double distance,
+            FollowRuntimeState state,
+            FollowWaitingReason reason,
+            boolean following,
+            boolean sprint,
+            boolean catchUp) {
+        return Arguments.of(
+                name, boundary, config, distance,
+                state, reason, following, sprint, catchUp);
+    }
+
+    private static Stream<Arguments> configs() {
+        return Stream.of(
+                Arguments.of("default", DEFAULT),
+                Arguments.of("custom", CUSTOM));
+    }
+
+    private static Stream<Arguments> invalidCustomOverrides() {
+        return Stream.of(
+                Arguments.of("only stop", 2.5, null),
+                Arguments.of("only start", null, 6.5),
+                Arguments.of("NaN", Double.NaN, 6.5),
+                Arguments.of("infinite stop", Double.POSITIVE_INFINITY, 6.5),
+                Arguments.of("infinite start", 2.5, Double.POSITIVE_INFINITY),
+                Arguments.of("negative", -1.0, 6.5),
+                Arguments.of("equal", 6.5, 6.5),
+                Arguments.of("stop above start", 7.0, 6.5),
+                Arguments.of("start equals sprint", 2.5, 9.0),
+                Arguments.of("start above sprint", 2.5, 9.000001));
+    }
+
+    private static FollowDecisions.Result decide(
+            FollowConfig config, double distance, boolean wasFollowing) {
+        return decide(config, distance, wasFollowing, null, null);
+    }
+
+    private static FollowDecisions.Result decide(
+            FollowConfig config,
+            double distance,
+            boolean wasFollowing,
+            Double stopOverride,
+            Double startOverride) {
+        return FollowDecisions.decide(
+                new FollowDecisions.Input(
+                        true, false, true, true, true, true, true,
+                        distance, stopOverride, startOverride, 10L),
+                wasFollowing,
+                FollowDecisions.NO_FAILED_COOLDOWN,
+                config);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowDecisionsTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowDecisionsTest.java
@@ -1,0 +1,389 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class FollowDecisionsTest {
+
+    @Test
+    void constantsHaveTheRequiredOrdering() {
+        assertTrue(FollowDecisions.DEFAULT_STOP_DISTANCE
+                < FollowDecisions.DEFAULT_START_DISTANCE);
+        assertTrue(FollowDecisions.DEFAULT_START_DISTANCE
+                < FollowDecisions.DEFAULT_SPRINT_DISTANCE);
+        assertTrue(FollowDecisions.DEFAULT_SPRINT_DISTANCE
+                <= FollowDecisions.DEFAULT_CATCH_UP_DISTANCE);
+        assertTrue(FollowDecisions.DEFAULT_CATCH_UP_DISTANCE
+                < FollowDecisions.DEFAULT_LOST_DISTANCE);
+        assertEquals(100L, FollowDecisions.FAILED_COOLDOWN_TICKS);
+    }
+
+    @Test
+    void disabledHasExplicitRuntimeState() {
+        FollowDecisions.Result result = decide(input(false, false, 20.0, 0L), true);
+
+        assertDormant(result, FollowRuntimeState.DISABLED, FollowWaitingReason.NONE);
+        assertFalse(result.following());
+    }
+
+    @Test
+    void manualPauseHasExplicitRuntimeState() {
+        FollowDecisions.Result result = decide(input(true, true, 20.0, 0L), true);
+
+        assertDormant(result, FollowRuntimeState.MANUALLY_PAUSED, FollowWaitingReason.NONE);
+        assertFalse(result.following());
+    }
+
+    @Test
+    void inactiveCompanionWinsOverOtherConditions() {
+        FollowDecisions.Input input = new FollowDecisions.Input(
+                false, true, false, false, false, false, false,
+                Double.NaN, null, null, 10L);
+
+        FollowDecisions.Result result = decide(input, true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.COMPANION_NOT_ACTIVE);
+    }
+
+    @Test
+    void missingOwnerUuidIsOwnerInvalid() {
+        FollowDecisions.Input input = validInput(8.0, 0L, null, null);
+        input = new FollowDecisions.Input(true, false, true, false,
+                false, false, false, Double.NaN, null, null, 0L);
+
+        FollowDecisions.Result result = decide(input, true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_INVALID);
+        assertFalse(result.following());
+    }
+
+    @Test
+    void unresolvedOwnerIsOffline() {
+        FollowDecisions.Input input = new FollowDecisions.Input(
+                true, false, true, true, false, false, false,
+                Double.NaN, null, null, 0L);
+
+        FollowDecisions.Result result = decide(input, true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_OFFLINE);
+    }
+
+    @Test
+    void deadOrRemovedOwnerIsInvalid() {
+        FollowDecisions.Input input = new FollowDecisions.Input(
+                true, false, true, true, true, false, false,
+                Double.NaN, null, null, 0L);
+
+        FollowDecisions.Result result = decide(input, true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_INVALID);
+    }
+
+    @Test
+    void ownerInAnotherLevelHasDedicatedReason() {
+        FollowDecisions.Input input = new FollowDecisions.Input(
+                true, false, true, true, true, true, false,
+                Double.NaN, null, null, 0L);
+
+        FollowDecisions.Result result = decide(input, true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_OTHER_DIMENSION);
+    }
+
+    @Test
+    void nanDistanceIsOwnerInvalid() {
+        FollowDecisions.Result result = decide(input(true, false, Double.NaN, 0L), true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_INVALID);
+    }
+
+    @Test
+    void infiniteDistanceIsOwnerInvalid() {
+        FollowDecisions.Result result = decide(
+                input(true, false, Double.POSITIVE_INFINITY, 0L), true);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_INVALID);
+    }
+
+    @Test
+    void exactStopDistanceIsIdleAndClosesLatch() {
+        FollowDecisions.Result result = decide(
+                input(true, false, FollowDecisions.DEFAULT_STOP_DISTANCE, 0L), true);
+
+        assertDormant(result, FollowRuntimeState.IDLE_NEAR_OWNER,
+                FollowWaitingReason.NONE);
+        assertFalse(result.following());
+    }
+
+    @Test
+    void exactStartDistanceStartsFollowing() {
+        FollowDecisions.Result result = decide(
+                input(true, false, FollowDecisions.DEFAULT_START_DISTANCE, 0L), false);
+
+        assertFollowing(result);
+    }
+
+    @Test
+    void hysteresisBandRetainsOpenLatch() {
+        FollowDecisions.Result result = decide(input(true, false, 4.0, 0L), true);
+
+        assertFollowing(result);
+    }
+
+    @Test
+    void hysteresisBandRetainsClosedLatch() {
+        FollowDecisions.Result result = decide(input(true, false, 4.0, 0L), false);
+
+        assertDormant(result, FollowRuntimeState.IDLE_NEAR_OWNER,
+                FollowWaitingReason.NONE);
+    }
+
+    @Test
+    void distanceBelowSprintThresholdDisallowsSprint() {
+        FollowDecisions.Result result = decide(input(true, false, 11.99, 0L), false);
+
+        assertFollowing(result);
+        assertFalse(result.sprintAllowed());
+    }
+
+    @Test
+    void exactSprintThresholdAllowsSprint() {
+        FollowDecisions.Result result = decide(input(true, false, 12.0, 0L), false);
+
+        assertFollowing(result);
+        assertTrue(result.sprintAllowed());
+    }
+
+    @Test
+    void distanceBelowCatchUpThresholdIsNotCatchingUp() {
+        FollowDecisions.Result result = decide(input(true, false, 23.99, 0L), false);
+
+        assertTrue(result.sprintAllowed());
+        assertFalse(result.catchingUp());
+    }
+
+    @Test
+    void exactCatchUpThresholdEntersCatchUpMode() {
+        FollowDecisions.Result result = decide(input(true, false, 24.0, 0L), false);
+
+        assertTrue(result.sprintAllowed());
+        assertTrue(result.catchingUp());
+        assertEquals(FollowRuntimeState.FOLLOWING, result.runtimeState());
+    }
+
+    @Test
+    void distanceJustBelowLostThresholdStillFollows() {
+        FollowDecisions.Result result = decide(input(true, false, 63.99, 0L), false);
+
+        assertFollowing(result);
+        assertTrue(result.catchingUp());
+    }
+
+    @Test
+    void exactLostThresholdWaitsWithoutCooldown() {
+        FollowDecisions.Result result = decide(input(true, false, 64.0, 0L), true,
+                100L);
+
+        assertDormant(result, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.OWNER_TOO_FAR);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, result.failedUntilTick());
+    }
+
+    @Test
+    void distanceMetricIsThreeDimensionalEuclidean() {
+        assertEquals(13.0, FollowDecisions.distance3d(
+                1.0, 2.0, 3.0, 4.0, 6.0, 15.0), 1.0e-9);
+    }
+
+    @Test
+    void validOverridePairIsAcceptedTogether() {
+        FollowDecisions.Distances distances =
+                FollowDecisions.resolveDistances(4.0, 8.0);
+
+        assertEquals(new FollowDecisions.Distances(4.0, 8.0), distances);
+    }
+
+    @Test
+    void startOverrideAtSprintThresholdFallsBackAsAPair() {
+        assertDefaultDistances(FollowDecisions.resolveDistances(4.0, 12.0));
+    }
+
+    @Test
+    void startOverrideAboveSprintThresholdFallsBackAsAPair() {
+        assertDefaultDistances(FollowDecisions.resolveDistances(4.0, 12.01));
+    }
+
+    @Test
+    void partialAndNonFiniteOverridesFallBackAsAPair() {
+        assertDefaultDistances(FollowDecisions.resolveDistances(null, 8.0));
+        assertDefaultDistances(FollowDecisions.resolveDistances(4.0, null));
+        assertDefaultDistances(FollowDecisions.resolveDistances(Double.NaN, 8.0));
+        assertDefaultDistances(FollowDecisions.resolveDistances(
+                4.0, Double.POSITIVE_INFINITY));
+    }
+
+    @Test
+    void nonPositiveAndMisorderedOverridesFallBackAsAPair() {
+        assertDefaultDistances(FollowDecisions.resolveDistances(0.0, 8.0));
+        assertDefaultDistances(FollowDecisions.resolveDistances(-1.0, 8.0));
+        assertDefaultDistances(FollowDecisions.resolveDistances(8.0, 8.0));
+        assertDefaultDistances(FollowDecisions.resolveDistances(9.0, 8.0));
+    }
+
+    @Test
+    void failedNavigationStartsExactOneHundredTickCooldown() {
+        FollowDecisions.Result active = decide(input(true, false, 8.0, 50L), false);
+
+        FollowDecisions.Result failed = FollowDecisions.failedAt(active, 50L);
+
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN, failed.runtimeState());
+        assertEquals(150L, failed.failedUntilTick());
+        assertFalse(failed.sprintAllowed());
+        assertFalse(failed.catchingUp());
+    }
+
+    @Test
+    void cooldownIsActiveOneTickBeforeDeadline() {
+        FollowDecisions.Result result = decide(input(true, false, 8.0, 149L),
+                true, 150L);
+
+        assertDormant(result, FollowRuntimeState.FAILED_COOLDOWN,
+                FollowWaitingReason.NONE);
+        assertEquals(150L, result.failedUntilTick());
+    }
+
+    @Test
+    void cooldownExpiresExactlyAtDeadline() {
+        FollowDecisions.Result result = decide(input(true, false, 8.0, 150L),
+                true, 150L);
+
+        assertFollowing(result);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, result.failedUntilTick());
+    }
+
+    @Test
+    void repeatedFailureResetsDeadlineFromCurrentTick() {
+        FollowDecisions.Result active = decide(input(true, false, 8.0, 150L), true);
+
+        FollowDecisions.Result failedAgain = FollowDecisions.failedAt(active, 150L);
+
+        assertEquals(250L, failedAgain.failedUntilTick());
+    }
+
+    @Test
+    void disabledClearsExistingCooldown() {
+        FollowDecisions.Result result = decide(input(false, false, 8.0, 60L),
+                true, 150L);
+
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, result.failedUntilTick());
+    }
+
+    @Test
+    void ownerInvalidClearsExistingCooldown() {
+        FollowDecisions.Input input = new FollowDecisions.Input(
+                true, false, true, true, true, false, false,
+                Double.NaN, null, null, 60L);
+
+        FollowDecisions.Result result = decide(input, true, 150L);
+
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, result.failedUntilTick());
+    }
+
+    @Test
+    void everyIneligibleWaitingStateClearsExistingCooldown() {
+        long deadline = 150L;
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                decide(input(true, true, 8.0, 60L), true, deadline)
+                        .failedUntilTick());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                decide(new FollowDecisions.Input(true, false, false, true,
+                        true, true, true, 8.0, null, null, 60L),
+                        true, deadline).failedUntilTick());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                decide(new FollowDecisions.Input(true, false, true, false,
+                        false, false, false, Double.NaN, null, null, 60L),
+                        true, deadline).failedUntilTick());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                decide(new FollowDecisions.Input(true, false, true, true,
+                        false, false, false, Double.NaN, null, null, 60L),
+                        true, deadline).failedUntilTick());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                decide(new FollowDecisions.Input(true, false, true, true,
+                        true, true, false, Double.NaN, null, null, 60L),
+                        true, deadline).failedUntilTick());
+    }
+
+    @Test
+    void stopDistanceClearsExistingCooldownBeforeCooldownCheck() {
+        FollowDecisions.Result result = decide(input(true, false, 3.0, 60L),
+                true, 150L);
+
+        assertEquals(FollowRuntimeState.IDLE_NEAR_OWNER, result.runtimeState());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, result.failedUntilTick());
+    }
+
+    @Test
+    void remainingCooldownUsesExactDeadlineBoundary() {
+        assertEquals(100L, FollowDecisions.remainingCooldownTicks(150L, 50L));
+        assertEquals(1L, FollowDecisions.remainingCooldownTicks(150L, 149L));
+        assertEquals(0L, FollowDecisions.remainingCooldownTicks(150L, 150L));
+        assertEquals(0L, FollowDecisions.remainingCooldownTicks(
+                FollowDecisions.NO_FAILED_COOLDOWN, 50L));
+    }
+
+    private static FollowDecisions.Result decide(
+            FollowDecisions.Input input, boolean wasFollowing) {
+        return decide(input, wasFollowing, FollowDecisions.NO_FAILED_COOLDOWN);
+    }
+
+    private static FollowDecisions.Result decide(
+            FollowDecisions.Input input, boolean wasFollowing, long failedUntilTick) {
+        return FollowDecisions.decide(input, wasFollowing, failedUntilTick);
+    }
+
+    private static FollowDecisions.Input input(
+            boolean enabled, boolean manualPaused, double distance, long currentTick) {
+        return new FollowDecisions.Input(enabled, manualPaused,
+                true, true, true, true, true, distance,
+                null, null, currentTick);
+    }
+
+    private static FollowDecisions.Input validInput(
+            double distance, long currentTick, Double stopOverride, Double startOverride) {
+        return new FollowDecisions.Input(true, false,
+                true, true, true, true, true, distance,
+                stopOverride, startOverride, currentTick);
+    }
+
+    private static void assertDormant(
+            FollowDecisions.Result result,
+            FollowRuntimeState expectedState,
+            FollowWaitingReason expectedReason) {
+        assertEquals(expectedState, result.runtimeState());
+        assertEquals(expectedReason, result.waitingReason());
+        assertEquals(Float.NEGATIVE_INFINITY, result.priority());
+        assertFalse(result.sprintAllowed());
+        assertFalse(result.catchingUp());
+    }
+
+    private static void assertFollowing(FollowDecisions.Result result) {
+        assertEquals(FollowRuntimeState.FOLLOWING, result.runtimeState());
+        assertEquals(FollowWaitingReason.NONE, result.waitingReason());
+        assertEquals(FollowDecisions.PRIORITY, result.priority());
+        assertTrue(result.following());
+    }
+
+    private static void assertDefaultDistances(FollowDecisions.Distances distances) {
+        assertEquals(new FollowDecisions.Distances(3.0, 5.5), distances);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowMultiCompanionPersistenceTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowMultiCompanionPersistenceTest.java
@@ -1,0 +1,91 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.reload;
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.state;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FollowMultiCompanionPersistenceTest {
+
+    @Test
+    void threeCompanionCombinationRemainsIsolatedAcrossRestartMutationAndDelete() {
+        UUID companionA = UUID.randomUUID();
+        UUID companionB = UUID.randomUUID();
+        UUID companionC = UUID.randomUUID();
+        FollowState stateA = state(true, false, 2.5, 6.5);
+        FollowState stateB = state(true, true, null, null);
+        FollowState stateC = FollowState.defaults();
+        FollowStateStore store = new FollowStateStore();
+        store.put(companionA, stateA);
+        store.put(companionB, stateB);
+        store.put(companionC, stateC);
+
+        FollowStateStore loaded = reload(store);
+        assertEquals(stateA, loaded.getOrDefault(companionA));
+        assertEquals(stateB, loaded.getOrDefault(companionB));
+        assertEquals(stateC, loaded.getOrDefault(companionC));
+
+        loaded.setControlState(companionA, false, false);
+        assertEquals(stateB, loaded.getOrDefault(companionB));
+        assertEquals(stateC, loaded.getOrDefault(companionC));
+        assertEquals(2.5,
+                loaded.getOrDefault(companionA).stopDistanceOverride());
+        assertEquals(null,
+                loaded.getOrDefault(companionB).stopDistanceOverride());
+        assertEquals(null,
+                loaded.getOrDefault(companionC).stopDistanceOverride());
+
+        loaded.remove(companionB);
+        assertEquals(2, loaded.size());
+        assertTrue(loaded.find(companionB).isEmpty());
+        assertTrue(loaded.find(companionA).isPresent());
+        assertTrue(loaded.find(companionC).isPresent());
+    }
+
+    @Test
+    void runtimeStatusAndStoreInstancesNeverCrossCompanionBoundaries() {
+        UUID companionA = UUID.randomUUID();
+        UUID companionB = UUID.randomUUID();
+        UUID companionC = UUID.randomUUID();
+        FollowStateStore firstStore = new FollowStateStore();
+        firstStore.put(companionA, state(true, false, 2.5, 6.5));
+        firstStore.put(companionB, state(true, true, null, null));
+        firstStore.put(companionC, FollowState.defaults());
+        firstStore.bindRuntime(
+                companionA,
+                new FollowStage7ATestSupport.TrackingControl(
+                        companionA,
+                        new FollowRuntimeSnapshot(
+                                FollowRuntimeState.FOLLOWING,
+                                FollowWaitingReason.NONE,
+                                true, true, false, false,
+                                FollowDecisions.NO_FAILED_COOLDOWN, 0L)));
+
+        FollowStatus statusA = FollowService.status(
+                firstStore,
+                FollowStage7ATestSupport.subject(
+                        companionA, true, true, true, true,
+                        OptionalDouble.of(8.0), 100L),
+                FollowConfig.defaults());
+
+        assertTrue(statusA.runtimeAvailable());
+        assertEquals(1, firstStore.runtimeControlCount());
+        assertTrue(firstStore.runtimeControl(companionB).isEmpty());
+        assertTrue(firstStore.runtimeControl(companionC).isEmpty());
+
+        FollowStateStore restartedStore = reload(firstStore);
+        FollowStateStore unrelatedStore = new FollowStateStore();
+
+        assertEquals(state(true, false, 2.5, 6.5),
+                restartedStore.getOrDefault(companionA));
+        assertEquals(0, restartedStore.runtimeControlCount());
+        assertEquals(0, unrelatedStore.runtimeControlCount());
+        assertFalse(unrelatedStore.find(companionA).isPresent());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowOwnerToolTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowOwnerToolTest.java
@@ -1,0 +1,203 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+class FollowOwnerToolTest {
+
+    private static final FollowConfig CONFIG = FollowConfig.defaults();
+
+    @Test
+    void toolNameIsExact() {
+        assertEquals("follow_owner", new FollowOwnerTool(CONFIG).name());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void schemaAcceptsOnlyOneRequiredFiveValueAction() {
+        Map<String, Object> schema =
+                new FollowOwnerTool(CONFIG).parameterSchema();
+        Map<String, Object> properties =
+                (Map<String, Object>) schema.get("properties");
+        Map<String, Object> action =
+                (Map<String, Object>) properties.get("action");
+
+        assertEquals(List.of("action"), schema.get("required"));
+        assertEquals(false, schema.get("additionalProperties"));
+        assertEquals(1, properties.size());
+        assertEquals("string", action.get("type"));
+        assertEquals(List.of("on", "off", "pause", "resume", "status"),
+                action.get("enum"));
+    }
+
+    @Test
+    void descriptionDistinguishesPersistentFollowFromGotoAndTeleport() {
+        String description = new FollowOwnerTool(CONFIG).description();
+
+        assertTrue(description.contains("跟着我"));
+        assertTrue(description.contains("以后别跟了"));
+        assertTrue(description.contains("先在这里等一下"));
+        assertTrue(description.contains("继续跟我"));
+        assertTrue(description.contains("你为什么不动"));
+        assertTrue(description.contains("goto"));
+        assertTrue(description.contains("去某坐标"));
+        assertTrue(description.contains("does not teleport"));
+        assertTrue(description.contains("OwnerFollowChain"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FollowAction.class)
+    void parserAcceptsEveryActionCaseInsensitively(FollowAction action) {
+        JsonObject args = new JsonObject();
+        args.addProperty("action", action.name());
+
+        assertEquals(action, FollowOwnerTool.parseArguments(args));
+    }
+
+    @Test
+    void unknownActionIsRejectedBeforeAnyControlCall() {
+        JsonObject args = new JsonObject();
+        args.addProperty("action", "goto");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> FollowOwnerTool.parseArguments(args));
+    }
+
+    @Test
+    void missingOrNonStringActionIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FollowOwnerTool.parseArguments(new JsonObject()));
+        JsonObject numeric = new JsonObject();
+        numeric.addProperty("action", 1);
+        assertThrows(IllegalArgumentException.class,
+                () -> FollowOwnerTool.parseArguments(numeric));
+    }
+
+    @Test
+    void companionNameUuidDistanceAndConfigArgumentsAreRejected() {
+        for (String forbidden : List.of(
+                "companion_name", "companion_uuid", "owner_uuid",
+                "distance", "config", "teleport", "allow_break")) {
+            JsonObject args = new JsonObject();
+            args.addProperty("action", "status");
+            args.addProperty(forbidden, "forbidden");
+            assertThrows(IllegalArgumentException.class,
+                    () -> FollowOwnerTool.parseArguments(args));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(FollowAction.class)
+    void everyParsedActionIsPassedUnchangedToSharedControlInvoker(
+            FollowAction action) {
+        List<FollowAction> calls = new ArrayList<>();
+        FollowControlResult expected = result(action, true);
+        FollowOwnerTool tool = new FollowOwnerTool(
+                CONFIG,
+                (server, companion, actual, config) -> {
+                    calls.add(actual);
+                    assertSame(CONFIG, config);
+                    return expected;
+                });
+
+        FollowControlResult actual =
+                tool.invokeControl(null, null, action);
+
+        assertSame(expected, actual);
+        assertEquals(List.of(action), calls);
+    }
+
+    @Test
+    void toolSerializesTheRealControlResultAndStableCode() {
+        FollowControlResult expected =
+                new FollowControlResult(
+                        FollowAction.OFF,
+                        true,
+                        true,
+                        "DISABLED",
+                        "已关闭自动跟随并释放当前移动控制。",
+                        status(false, false));
+
+        JsonObject json = JsonParser.parseString(
+                FollowOwnerTool.resultJson(expected)).getAsJsonObject();
+
+        assertTrue(json.get("success").getAsBoolean());
+        assertEquals(expected.message(), json.get("message").getAsString());
+        assertEquals("DISABLED",
+                json.getAsJsonObject("data").get("code").getAsString());
+        assertTrue(json.getAsJsonObject("data").get("changed").getAsBoolean());
+    }
+
+    @Test
+    void failedControlResultRemainsARealToolFailure() {
+        FollowControlResult expected =
+                new FollowControlResult(
+                        FollowAction.PAUSE,
+                        false,
+                        false,
+                        "PAUSE_REQUIRES_ENABLED",
+                        "自动跟随当前已关闭；请使用 on 或 resume 启用。",
+                        status(false, false));
+
+        JsonObject json = JsonParser.parseString(
+                FollowOwnerTool.resultJson(expected)).getAsJsonObject();
+
+        assertFalse(json.get("success").getAsBoolean());
+        assertEquals("PAUSE_REQUIRES_ENABLED",
+                json.getAsJsonObject("data").get("code").getAsString());
+    }
+
+    @Test
+    void actionEnumHasExactlyTheFiveApprovedNonPersistentValues() {
+        assertEquals(List.of(
+                        FollowAction.ON,
+                        FollowAction.OFF,
+                        FollowAction.PAUSE,
+                        FollowAction.RESUME,
+                        FollowAction.STATUS),
+                List.of(FollowAction.values()));
+        assertTrue(FollowAction.parse(" ReSuMe ").isPresent());
+        assertTrue(FollowAction.parse("unknown").isEmpty());
+    }
+
+    private static FollowControlResult result(
+            FollowAction action, boolean success) {
+        return new FollowControlResult(
+                action, success, true, action.name(), "result",
+                status(true, false));
+    }
+
+    private static FollowStatus status(boolean enabled, boolean paused) {
+        return new FollowStatus(
+                UUID.randomUUID(),
+                "Numen",
+                enabled,
+                paused,
+                false,
+                enabled
+                        ? FollowRuntimeState.WAITING_FOR_OWNER
+                        : FollowRuntimeState.DISABLED,
+                enabled
+                        ? FollowWaitingReason.OWNER_INVALID
+                        : FollowWaitingReason.NONE,
+                false, false, false, false, 0L,
+                true, true, true, OptionalDouble.of(8.0),
+                3.0, 5.5, 12.0, 24.0, 64.0, 100L);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowRuntimeContractsTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowRuntimeContractsTest.java
@@ -61,7 +61,7 @@ class FollowRuntimeContractsTest {
                         null, null, FollowReleaseReason.FOLLOW_DISABLED));
         assertThrows(NullPointerException.class,
                 () -> FollowService.removeRuntime(
-                        null, UUID.randomUUID(), null));
+                        null, null, null));
         assertThrows(NullPointerException.class,
                 () -> FollowService.runtimeSnapshot(
                         null, null, 0L));

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowRuntimeContractsTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowRuntimeContractsTest.java
@@ -1,0 +1,69 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FollowRuntimeContractsTest {
+
+    @Test
+    void releaseReasonsRemainSmallExplicitAndNonPersistent() {
+        assertEquals(List.of(
+                FollowReleaseReason.SCHEDULER_INTERRUPT,
+                FollowReleaseReason.FOLLOW_DISABLED,
+                FollowReleaseReason.MANUAL_PAUSE,
+                FollowReleaseReason.COMPANION_DEATH,
+                FollowReleaseReason.COMPANION_REMOVED,
+                FollowReleaseReason.SERVER_STOPPING,
+                FollowReleaseReason.RUNTIME_REPLACED,
+                FollowReleaseReason.INTERNAL_STATE_CHANGE),
+                List.of(FollowReleaseReason.values()));
+    }
+
+    @Test
+    void snapshotContainsOnlyImmutableRuntimeValues() {
+        FollowRuntimeSnapshot snapshot = new FollowRuntimeSnapshot(
+                FollowRuntimeState.FAILED_COOLDOWN,
+                FollowWaitingReason.NONE,
+                false,
+                false,
+                false,
+                false,
+                150L,
+                25L);
+
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN, snapshot.runtimeState());
+        assertEquals(FollowWaitingReason.NONE, snapshot.waitingReason());
+        assertEquals(150L, snapshot.failedUntilTick());
+        assertEquals(25L, snapshot.remainingCooldownTicks());
+        assertFalse(snapshot.navigationActive());
+    }
+
+    @Test
+    void followServiceRejectsNullServerBeforeStoreAccess() {
+        assertThrows(NullPointerException.class,
+                () -> FollowService.releaseRuntime(
+                        null, UUID.randomUUID(), FollowReleaseReason.FOLLOW_DISABLED));
+        assertThrows(NullPointerException.class,
+                () -> FollowService.releaseAllRuntime(
+                        null, FollowReleaseReason.SERVER_STOPPING));
+    }
+
+    @Test
+    void followServiceRejectsInvalidNullArgumentSets() {
+        assertThrows(NullPointerException.class,
+                () -> FollowService.releaseRuntime(
+                        null, null, FollowReleaseReason.FOLLOW_DISABLED));
+        assertThrows(NullPointerException.class,
+                () -> FollowService.removeRuntime(
+                        null, UUID.randomUUID(), null));
+        assertThrows(NullPointerException.class,
+                () -> FollowService.runtimeSnapshot(
+                        null, null, 0L));
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowServiceControlTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowServiceControlTest.java
@@ -1,0 +1,369 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FollowServiceControlTest {
+
+    private static final FollowConfig CONFIG = FollowConfig.defaults();
+
+    @Test
+    void onAtomicallyEnablesAndClearsPause() {
+        Fixture fixture = fixture(new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, 3.5, 6.0));
+
+        FollowControlResult result = fixture.apply(FollowAction.ON);
+
+        assertEquals(new FollowState(
+                        true, false, FollowState.CURRENT_SCHEMA_VERSION, 3.5, 6.0),
+                fixture.state());
+        assertEquals("ENABLED", result.code());
+        assertTrue(result.changed());
+        assertTrue(fixture.store.isDirty());
+    }
+
+    @Test
+    void onDoesNotCreateNavigationRuntimeOrCallRelease() {
+        Fixture fixture = fixture(FollowState.defaults());
+
+        fixture.apply(FollowAction.ON);
+
+        assertEquals(0, fixture.store.runtimeControlCount());
+    }
+
+    @Test
+    void repeatedOnIsIdempotentWithoutDirtying() {
+        Fixture fixture = fixture(enabled());
+        fixture.store.setDirty(false);
+
+        FollowControlResult result = fixture.apply(FollowAction.ON);
+
+        assertEquals("ALREADY_ENABLED", result.code());
+        assertFalse(result.changed());
+        assertFalse(fixture.store.isDirty());
+    }
+
+    @Test
+    void offAtomicallyDisablesClearsPauseAndReleasesImmediately() {
+        Fixture fixture = fixture(new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, null, null));
+        FakeControl control = fixture.bindControl();
+
+        FollowControlResult result = fixture.apply(FollowAction.OFF);
+
+        assertEquals(new FollowState(
+                        false, false, FollowState.CURRENT_SCHEMA_VERSION, null, null),
+                fixture.state());
+        assertEquals(List.of(FollowReleaseReason.FOLLOW_DISABLED), control.reasons);
+        assertEquals("DISABLED", result.code());
+    }
+
+    @Test
+    void alreadyOffStillDefensivelyReleasesAndRetainsBinding() {
+        Fixture fixture = fixture(FollowState.defaults());
+        FakeControl control = fixture.bindControl();
+        fixture.store.setDirty(false);
+
+        FollowControlResult result = fixture.apply(FollowAction.OFF);
+
+        assertEquals("ALREADY_DISABLED", result.code());
+        assertFalse(result.changed());
+        assertFalse(fixture.store.isDirty());
+        assertEquals(List.of(FollowReleaseReason.FOLLOW_DISABLED), control.reasons);
+        assertSame(control,
+                fixture.store.runtimeControl(fixture.uuid).orElseThrow());
+    }
+
+    @Test
+    void pauseRequiresEnabledAndDoesNotReleaseWhenRejected() {
+        Fixture fixture = fixture(FollowState.defaults());
+        FakeControl control = fixture.bindControl();
+        fixture.store.setDirty(false);
+
+        FollowControlResult result = fixture.apply(FollowAction.PAUSE);
+
+        assertFalse(result.success());
+        assertEquals("PAUSE_REQUIRES_ENABLED", result.code());
+        assertFalse(result.changed());
+        assertEquals(List.of(), control.reasons);
+        assertEquals(FollowState.defaults(), fixture.state());
+        assertFalse(fixture.store.isDirty());
+    }
+
+    @Test
+    void pauseEnabledStateAndReleasesImmediately() {
+        Fixture fixture = fixture(enabled());
+        FakeControl control = fixture.bindControl();
+
+        FollowControlResult result = fixture.apply(FollowAction.PAUSE);
+
+        assertEquals(new FollowState(
+                        true, true, FollowState.CURRENT_SCHEMA_VERSION, null, null),
+                fixture.state());
+        assertEquals("PAUSED", result.code());
+        assertEquals(List.of(FollowReleaseReason.MANUAL_PAUSE), control.reasons);
+    }
+
+    @Test
+    void repeatedPauseIsIdempotentButStillDefensivelyReleases() {
+        Fixture fixture = fixture(new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, null, null));
+        FakeControl control = fixture.bindControl();
+        fixture.store.setDirty(false);
+
+        FollowControlResult result = fixture.apply(FollowAction.PAUSE);
+
+        assertEquals("ALREADY_PAUSED", result.code());
+        assertFalse(result.changed());
+        assertFalse(fixture.store.isDirty());
+        assertEquals(List.of(FollowReleaseReason.MANUAL_PAUSE), control.reasons);
+    }
+
+    @Test
+    void resumeFromPausedSetsEnabledAndClearsPauseWithoutRelease() {
+        Fixture fixture = fixture(new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, null, null));
+        FakeControl control = fixture.bindControl();
+
+        FollowControlResult result = fixture.apply(FollowAction.RESUME);
+
+        assertEquals(enabled(), fixture.state());
+        assertEquals("RESUMED", result.code());
+        assertEquals(List.of(), control.reasons);
+    }
+
+    @Test
+    void resumeFromDisabledEnablesWithoutCreatingRuntime() {
+        Fixture fixture = fixture(FollowState.defaults());
+
+        FollowControlResult result = fixture.apply(FollowAction.RESUME);
+
+        assertEquals(enabled(), fixture.state());
+        assertEquals("RESUMED", result.code());
+        assertEquals(0, fixture.store.runtimeControlCount());
+    }
+
+    @Test
+    void repeatedResumeIsIdempotentWithoutDirtying() {
+        Fixture fixture = fixture(enabled());
+        fixture.store.setDirty(false);
+
+        FollowControlResult result = fixture.apply(FollowAction.RESUME);
+
+        assertEquals("ALREADY_RESUMED", result.code());
+        assertFalse(result.changed());
+        assertFalse(fixture.store.isDirty());
+    }
+
+    @Test
+    void statusIsCompletelyReadOnlyAndDoesNotCreateRuntime() {
+        Fixture fixture = fixture(enabled());
+        fixture.store.setDirty(false);
+
+        FollowControlResult result = fixture.apply(FollowAction.STATUS);
+
+        assertEquals("STATUS", result.code());
+        assertFalse(result.changed());
+        assertFalse(fixture.store.isDirty());
+        assertEquals(0, fixture.store.runtimeControlCount());
+    }
+
+    @Test
+    void everyActionPreservesSchemaAndDistanceOverrides() {
+        Fixture fixture = fixture(new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, 3.5, 6.0));
+
+        fixture.apply(FollowAction.PAUSE);
+        fixture.apply(FollowAction.OFF);
+        fixture.apply(FollowAction.RESUME);
+
+        FollowState state = fixture.state();
+        assertEquals(FollowState.CURRENT_SCHEMA_VERSION, state.schemaVersion());
+        assertEquals(3.5, state.stopDistanceOverride());
+        assertEquals(6.0, state.startDistanceOverride());
+    }
+
+    @Test
+    void atomicStoreUpdateChangesBothBitsInOneVisibleValue() {
+        Fixture fixture = fixture(new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, 3.5, 6.0));
+        fixture.store.setDirty(false);
+
+        boolean changed = fixture.store.setControlState(
+                fixture.uuid, false, false);
+
+        assertTrue(changed);
+        assertEquals(new FollowState(
+                        false, false, FollowState.CURRENT_SCHEMA_VERSION, 3.5, 6.0),
+                fixture.state());
+        assertTrue(fixture.store.isDirty());
+    }
+
+    @Test
+    void atomicStoreNoOpDoesNotDirtyOrTouchRuntime() {
+        Fixture fixture = fixture(enabled());
+        FakeControl control = fixture.bindControl();
+        fixture.store.setDirty(false);
+
+        boolean changed = fixture.store.setControlState(
+                fixture.uuid, true, false);
+
+        assertFalse(changed);
+        assertFalse(fixture.store.isDirty());
+        assertSame(control,
+                fixture.store.runtimeControl(fixture.uuid).orElseThrow());
+    }
+
+    @Test
+    void releaseFailureDoesNotRollBackPersistentOffAndReturnsWarning() {
+        Fixture fixture = fixture(enabled());
+        FakeControl control = fixture.bindControl();
+        control.throwOnRelease = true;
+
+        FollowControlResult result = fixture.apply(FollowAction.OFF);
+
+        assertEquals(FollowState.defaults(), fixture.state());
+        assertTrue(result.success());
+        assertTrue(result.changed());
+        assertEquals("RUNTIME_RELEASE_WARNING", result.code());
+        assertTrue(result.message().contains("未能确认完全释放"));
+    }
+
+    @Test
+    void releaseFailureDoesNotRollBackPersistentPauseAndReturnsWarning() {
+        Fixture fixture = fixture(enabled());
+        FakeControl control = fixture.bindControl();
+        control.throwOnRelease = true;
+
+        FollowControlResult result = fixture.apply(FollowAction.PAUSE);
+
+        assertTrue(fixture.state().enabled());
+        assertTrue(fixture.state().manualPaused());
+        assertEquals("RUNTIME_RELEASE_WARNING", result.code());
+    }
+
+    @Test
+    void invalidCompanionOrMissingOwnerIsRejectedWithoutMutation() {
+        FollowStateStore store = new FollowStateStore();
+        UUID uuid = UUID.randomUUID();
+        FollowService.Subject subject = new FollowService.Subject(
+                uuid, "N", true, false, false, false, false,
+                OptionalDouble.empty(), 1L);
+
+        FollowControlResult result =
+                FollowService.apply(store, subject, FollowAction.ON, CONFIG);
+
+        assertFalse(result.success());
+        assertEquals("INVALID_COMPANION", result.code());
+        assertEquals(FollowState.defaults(), store.getOrDefault(uuid));
+        assertFalse(store.isDirty());
+    }
+
+    @Test
+    void statusStillExplainsMissingOwnerWithoutMutatingAnything() {
+        FollowStateStore store = new FollowStateStore();
+        UUID uuid = UUID.randomUUID();
+        store.put(uuid, enabled());
+        store.setDirty(false);
+        FollowService.Subject subject = new FollowService.Subject(
+                uuid, "N", true, false, false, false, false,
+                OptionalDouble.empty(), 1L);
+
+        FollowControlResult result =
+                FollowService.apply(store, subject, FollowAction.STATUS, CONFIG);
+
+        assertTrue(result.success());
+        assertEquals("STATUS", result.code());
+        assertEquals(FollowWaitingReason.OWNER_INVALID,
+                result.status().waitingReason());
+        assertFalse(store.isDirty());
+        assertEquals(0, store.runtimeControlCount());
+    }
+
+    private static Fixture fixture(FollowState state) {
+        Fixture fixture = new Fixture();
+        fixture.store.put(fixture.uuid, state);
+        return fixture;
+    }
+
+    private static FollowState enabled() {
+        return new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, null, null);
+    }
+
+    private static final class Fixture {
+        final UUID uuid = UUID.randomUUID();
+        final FollowStateStore store = new FollowStateStore();
+        final FollowService.Subject subject = new FollowService.Subject(
+                uuid, "Numen", true, true, true, true, true,
+                OptionalDouble.of(8.0), 50L);
+
+        FollowControlResult apply(FollowAction action) {
+            return FollowService.apply(store, subject, action, CONFIG);
+        }
+
+        FollowState state() {
+            return store.getOrDefault(uuid);
+        }
+
+        FakeControl bindControl() {
+            FakeControl control = new FakeControl(uuid);
+            store.bindRuntime(uuid, control);
+            return control;
+        }
+    }
+
+    private static final class FakeControl implements FollowRuntimeControl {
+        private final UUID uuid;
+        private final List<FollowReleaseReason> reasons = new ArrayList<>();
+        private boolean throwOnRelease;
+        private FollowRuntimeSnapshot snapshot = new FollowRuntimeSnapshot(
+                FollowRuntimeState.FOLLOWING,
+                FollowWaitingReason.NONE,
+                true, true, true, false,
+                FollowDecisions.NO_FAILED_COOLDOWN, 0L);
+
+        private FakeControl(UUID uuid) {
+            this.uuid = uuid;
+        }
+
+        @Override
+        public UUID companionUuid() {
+            return uuid;
+        }
+
+        @Override
+        public void release(FollowReleaseReason reason) {
+            reasons.add(reason);
+            snapshot = switch (reason) {
+                case FOLLOW_DISABLED -> inactive(FollowRuntimeState.DISABLED);
+                case MANUAL_PAUSE -> inactive(FollowRuntimeState.MANUALLY_PAUSED);
+                default -> inactive(FollowRuntimeState.WAITING_FOR_OWNER);
+            };
+            if (throwOnRelease) {
+                throw new IllegalStateException("deliberate release failure");
+            }
+        }
+
+        @Override
+        public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+            return snapshot;
+        }
+
+        private static FollowRuntimeSnapshot inactive(FollowRuntimeState state) {
+            return new FollowRuntimeSnapshot(
+                    state, FollowWaitingReason.NONE,
+                    false, false, false, false,
+                    FollowDecisions.NO_FAILED_COOLDOWN, 0L);
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStage7ATestSupport.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStage7ATestSupport.java
@@ -1,0 +1,84 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import net.minecraft.nbt.CompoundTag;
+
+final class FollowStage7ATestSupport {
+
+    private FollowStage7ATestSupport() {}
+
+    static FollowState state(
+            boolean enabled,
+            boolean paused,
+            Double stopOverride,
+            Double startOverride) {
+        return new FollowState(
+                enabled,
+                paused,
+                FollowState.CURRENT_SCHEMA_VERSION,
+                stopOverride,
+                startOverride);
+    }
+
+    static FollowStateStore reload(FollowStateStore store) {
+        return FollowStateStore.load(store.save(new CompoundTag()));
+    }
+
+    static FollowService.Subject subject(
+            UUID companionUuid,
+            boolean ownerPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameDimension,
+            OptionalDouble distance,
+            long gameTime) {
+        return new FollowService.Subject(
+                companionUuid,
+                "Numen",
+                true,
+                ownerPresent,
+                ownerOnline,
+                ownerValid,
+                sameDimension,
+                distance,
+                gameTime);
+    }
+
+    static final class TrackingControl implements FollowRuntimeControl {
+        private final UUID companionUuid;
+        private final List<FollowReleaseReason> reasons = new ArrayList<>();
+        private FollowRuntimeSnapshot snapshot;
+
+        TrackingControl(UUID companionUuid, FollowRuntimeSnapshot snapshot) {
+            this.companionUuid = companionUuid;
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public UUID companionUuid() {
+            return companionUuid;
+        }
+
+        @Override
+        public void release(FollowReleaseReason reason) {
+            reasons.add(reason);
+        }
+
+        @Override
+        public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+            return snapshot;
+        }
+
+        List<FollowReleaseReason> reasons() {
+            return List.copyOf(reasons);
+        }
+
+        void snapshot(FollowRuntimeSnapshot value) {
+            snapshot = value;
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateIsolationTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateIsolationTest.java
@@ -1,0 +1,62 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FollowStateIsolationTest {
+
+    @Test
+    void companionUuidKeysKeepStatesIsolated() {
+        UUID companionA = UUID.randomUUID();
+        UUID companionB = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+
+        store.setEnabled(companionA, true);
+        store.setManualPaused(companionB, true);
+        store.setDistanceOverrides(companionA, 3.0, 5.5);
+
+        assertTrue(store.getOrDefault(companionA).enabled());
+        assertFalse(store.getOrDefault(companionA).manualPaused());
+        assertEquals(3.0, store.getOrDefault(companionA).stopDistanceOverride());
+
+        assertFalse(store.getOrDefault(companionB).enabled());
+        assertTrue(store.getOrDefault(companionB).manualPaused());
+        assertEquals(null, store.getOrDefault(companionB).stopDistanceOverride());
+    }
+
+    @Test
+    void snapshotCannotMutateStore() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.setEnabled(companion, true);
+
+        Map<UUID, FollowState> snapshot = store.snapshot();
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> snapshot.put(UUID.randomUUID(), FollowState.defaults()));
+        assertEquals(1, store.size());
+    }
+
+    @Test
+    void followStoreHasNoGlobalStaticStateContainer() {
+        for (Field field : FollowStateStore.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            Class<?> type = field.getType();
+            assertFalse(Map.class.isAssignableFrom(type),
+                    () -> "static map would create global follow state: " + field.getName());
+            assertFalse(type == FollowState.class || type == FollowStateStore.class,
+                    () -> "static follow object would create global state: " + field.getName());
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStatePersistenceRegressionTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStatePersistenceRegressionTest.java
@@ -1,0 +1,185 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.reload;
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.state;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+
+class FollowStatePersistenceRegressionTest {
+
+    @Test
+    void emptyStoreRoundTripsThroughRealNbt() {
+        FollowStateStore original = new FollowStateStore();
+
+        CompoundTag saved = original.save(new CompoundTag());
+        FollowStateStore loaded = FollowStateStore.load(saved);
+
+        assertEquals(Set.of("entries"), saved.getAllKeys());
+        assertEquals(0, saved.getList("entries", Tag.TAG_COMPOUND).size());
+        assertEquals(0, loaded.size());
+        assertEquals(0, loaded.runtimeControlCount());
+    }
+
+    @Test
+    void multipleCompanionsAndOverridesRoundTripTogether() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        UUID third = UUID.randomUUID();
+        FollowStateStore original = new FollowStateStore();
+        FollowState firstState = state(true, false, 2.5, 6.5);
+        FollowState secondState = state(true, true, null, null);
+        FollowState thirdState = state(false, false, 3.0, 7.0);
+        original.put(first, firstState);
+        original.put(second, secondState);
+        original.put(third, thirdState);
+
+        FollowStateStore loaded = reload(original);
+
+        assertEquals(3, loaded.size());
+        assertEquals(firstState, loaded.getOrDefault(first));
+        assertEquals(secondState, loaded.getOrDefault(second));
+        assertEquals(thirdState, loaded.getOrDefault(third));
+    }
+
+    @Test
+    void removingOneCompanionBeforeSaveDoesNotAffectOtherEntries() {
+        UUID retainedA = UUID.randomUUID();
+        UUID removed = UUID.randomUUID();
+        UUID retainedC = UUID.randomUUID();
+        FollowStateStore original = new FollowStateStore();
+        original.put(retainedA, state(true, false, 2.5, 6.5));
+        original.put(removed, state(true, true, null, null));
+        original.put(retainedC, FollowState.defaults());
+
+        original.remove(removed);
+        FollowStateStore loaded = reload(original);
+
+        assertEquals(2, loaded.size());
+        assertEquals(state(true, false, 2.5, 6.5),
+                loaded.getOrDefault(retainedA));
+        assertTrue(loaded.find(removed).isEmpty());
+        assertEquals(FollowState.defaults(), loaded.getOrDefault(retainedC));
+    }
+
+    @Test
+    void invalidUuidEntryIsDiscardedBesideValidEntry() {
+        UUID validUuid = UUID.randomUUID();
+        CompoundTag valid = validEntry(
+                validUuid, true, false, FollowState.CURRENT_SCHEMA_VERSION);
+        CompoundTag invalidUuid = new CompoundTag();
+        invalidUuid.putString("companionUuid", "not-a-uuid");
+        invalidUuid.putBoolean("enabled", true);
+        invalidUuid.putInt("schemaVersion", FollowState.CURRENT_SCHEMA_VERSION);
+
+        FollowStateStore loaded =
+                FollowStateStore.load(rootWith(valid, invalidUuid));
+
+        assertEquals(1, loaded.size());
+        assertTrue(loaded.getOrDefault(validUuid).enabled());
+    }
+
+    @Test
+    void savedNbtContainsOnlyApprovedPersistentFields() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.put(companion, state(true, false, 2.5, 6.5));
+        FollowStage7ATestSupport.TrackingControl runtime =
+                new FollowStage7ATestSupport.TrackingControl(
+                        companion,
+                        new FollowRuntimeSnapshot(
+                                FollowRuntimeState.FOLLOWING,
+                                FollowWaitingReason.NONE,
+                                true, true, true, true, 250L, 150L));
+        store.bindRuntime(companion, runtime);
+        FollowControlResult result = FollowService.apply(
+                store,
+                FollowStage7ATestSupport.subject(
+                        companion, true, true, true, true,
+                        java.util.OptionalDouble.of(8.0), 100L),
+                FollowAction.STATUS,
+                FollowConfig.defaults());
+
+        CompoundTag saved = store.save(new CompoundTag());
+        ListTag entries = saved.getList("entries", Tag.TAG_COMPOUND);
+        CompoundTag entry = entries.getCompound(0);
+        String text = saved.toString().toLowerCase(Locale.ROOT);
+
+        assertEquals(Set.of("entries"), saved.getAllKeys());
+        assertEquals(Set.of(
+                "companionUuid",
+                "enabled",
+                "manualPaused",
+                "schemaVersion",
+                "stopDistanceOverride",
+                "startDistanceOverride"), entry.getAllKeys());
+        for (String forbidden : List.of(
+                "owner",
+                "runtime",
+                "waiting",
+                "navigation",
+                "cooldown",
+                "following",
+                "sprint",
+                "catch",
+                "lost",
+                "allow_",
+                "follow_disabled",
+                result.code().toLowerCase(Locale.ROOT))) {
+            assertFalse(text.contains(forbidden), forbidden);
+        }
+    }
+
+    @Test
+    void sameUuidRetainsPersistentStateButDropsBoundRuntimeOnReload() {
+        UUID companion = UUID.randomUUID();
+        FollowState expected = state(true, true, 2.5, 6.5);
+        FollowStateStore original = new FollowStateStore();
+        original.put(companion, expected);
+        original.bindRuntime(
+                companion,
+                new FollowStage7ATestSupport.TrackingControl(
+                        companion,
+                        new FollowRuntimeSnapshot(
+                                FollowRuntimeState.FAILED_COOLDOWN,
+                                FollowWaitingReason.NONE,
+                                true, false, false, false, 500L, 400L)));
+
+        FollowStateStore loaded = reload(original);
+
+        assertEquals(expected, loaded.getOrDefault(companion));
+        assertEquals(0, loaded.runtimeControlCount());
+        assertTrue(loaded.runtimeControl(companion).isEmpty());
+    }
+
+    private static CompoundTag validEntry(
+            UUID uuid, boolean enabled, boolean paused, int schemaVersion) {
+        CompoundTag entry = new CompoundTag();
+        entry.putUUID("companionUuid", uuid);
+        entry.putBoolean("enabled", enabled);
+        entry.putBoolean("manualPaused", paused);
+        entry.putInt("schemaVersion", schemaVersion);
+        return entry;
+    }
+
+    private static CompoundTag rootWith(CompoundTag... values) {
+        ListTag entries = new ListTag();
+        for (CompoundTag value : values) {
+            entries.add(value);
+        }
+        CompoundTag root = new CompoundTag();
+        root.put("entries", entries);
+        return root;
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateRestartBoundaryTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateRestartBoundaryTest.java
@@ -1,0 +1,151 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.reload;
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.state;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import net.minecraft.nbt.CompoundTag;
+
+class FollowStateRestartBoundaryTest {
+
+    private static final FollowConfig CONFIG = FollowConfig.defaults();
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("controlCases")
+    void controlActionsPersistTheirExactRestartState(
+            String label,
+            FollowAction action,
+            FollowState initial,
+            FollowState expected) {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.put(companion, initial);
+        store.setDirty(false);
+
+        FollowControlResult result = FollowService.apply(
+                store, activeSubject(companion), action, CONFIG);
+        FollowStateStore loaded = reload(store);
+
+        assertTrue(result.success(), label);
+        assertEquals(expected, store.getOrDefault(companion), label);
+        assertEquals(expected, loaded.getOrDefault(companion), label);
+        assertEquals(FollowState.CURRENT_SCHEMA_VERSION,
+                loaded.getOrDefault(companion).schemaVersion(), label);
+        assertEquals(2.5,
+                loaded.getOrDefault(companion).stopDistanceOverride(), label);
+        assertEquals(6.5,
+                loaded.getOrDefault(companion).startDistanceOverride(), label);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FollowAction.class, names = {"OFF", "PAUSE"})
+    void releaseSideEffectsNeverEnterRestartedStore(FollowAction action) {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.put(companion, state(true, false, 2.5, 6.5));
+        FollowStage7ATestSupport.TrackingControl control =
+                new FollowStage7ATestSupport.TrackingControl(
+                        companion,
+                        new FollowRuntimeSnapshot(
+                                FollowRuntimeState.FOLLOWING,
+                                FollowWaitingReason.NONE,
+                                true, true, true, false, 400L, 300L));
+        store.bindRuntime(companion, control);
+
+        FollowService.apply(store, activeSubject(companion), action, CONFIG);
+        FollowStateStore loaded = reload(store);
+
+        FollowReleaseReason expectedReason = action == FollowAction.OFF
+                ? FollowReleaseReason.FOLLOW_DISABLED
+                : FollowReleaseReason.MANUAL_PAUSE;
+        assertEquals(List.of(expectedReason), control.reasons());
+        assertEquals(0, loaded.runtimeControlCount());
+        assertEquals(action == FollowAction.PAUSE,
+                loaded.getOrDefault(companion).enabled());
+        assertEquals(action == FollowAction.PAUSE,
+                loaded.getOrDefault(companion).manualPaused());
+    }
+
+    @Test
+    void failedCooldownLatchAndRuntimeStateNeverRestart() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.put(companion, state(true, false, 2.5, 6.5));
+        store.bindRuntime(
+                companion,
+                new FollowStage7ATestSupport.TrackingControl(
+                        companion,
+                        new FollowRuntimeSnapshot(
+                                FollowRuntimeState.FAILED_COOLDOWN,
+                                FollowWaitingReason.NONE,
+                                true, false, false, false, 500L, 400L)));
+
+        FollowStateStore loaded = reload(store);
+        FollowStatus status = FollowService.status(
+                loaded,
+                FollowStage7ATestSupport.subject(
+                        companion, true, false, false, false,
+                        OptionalDouble.empty(), 100L),
+                CONFIG);
+
+        assertFalse(status.runtimeAvailable());
+        assertFalse(status.following());
+        assertFalse(status.navigationActive());
+        assertEquals(0L, status.remainingCooldownTicks());
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, status.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_OFFLINE, status.waitingReason());
+        assertEquals(0, loaded.runtimeControlCount());
+    }
+
+    @Test
+    void noOpControlAndStatusAreSerializationNeutral() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        FollowState expected = state(true, false, 2.5, 6.5);
+        store.put(companion, expected);
+        String before = store.save(new CompoundTag()).toString();
+        store.setDirty(false);
+
+        FollowControlResult on = FollowService.apply(
+                store, activeSubject(companion), FollowAction.ON, CONFIG);
+        FollowControlResult status = FollowService.apply(
+                store, activeSubject(companion), FollowAction.STATUS, CONFIG);
+        String after = store.save(new CompoundTag()).toString();
+
+        assertFalse(on.changed());
+        assertFalse(status.changed());
+        assertFalse(store.isDirty());
+        assertEquals(expected, store.getOrDefault(companion));
+        assertEquals(before, after);
+    }
+
+    private static Stream<Arguments> controlCases() {
+        FollowState paused = state(true, true, 2.5, 6.5);
+        FollowState enabled = state(true, false, 2.5, 6.5);
+        FollowState disabled = state(false, false, 2.5, 6.5);
+        return Stream.of(
+                Arguments.of("ON", FollowAction.ON, paused, enabled),
+                Arguments.of("OFF", FollowAction.OFF, paused, disabled),
+                Arguments.of("PAUSE", FollowAction.PAUSE, enabled, paused),
+                Arguments.of("RESUME", FollowAction.RESUME, disabled, enabled));
+    }
+
+    private static FollowService.Subject activeSubject(UUID companion) {
+        return FollowStage7ATestSupport.subject(
+                companion, true, true, true, true,
+                OptionalDouble.of(8.0), 100L);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateStoreRuntimeControlTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateStoreRuntimeControlTest.java
@@ -1,0 +1,319 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.nbt.CompoundTag;
+
+class FollowStateStoreRuntimeControlTest {
+
+    @Test
+    void bindMakesControlDiscoverableByCompanionUuid() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+
+        store.bindRuntime(control.companionUuid(), control);
+
+        assertSame(control, store.runtimeControl(control.companionUuid()).orElseThrow());
+        assertEquals(1, store.runtimeControlCount());
+    }
+
+    @Test
+    void duplicateBindingOfSameControlIsNoOp() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+
+        store.bindRuntime(control.companionUuid(), control);
+        store.bindRuntime(control.companionUuid(), control);
+
+        assertEquals(List.of(), control.reasons);
+        assertEquals(1, store.runtimeControlCount());
+    }
+
+    @Test
+    void replacementIsInstalledBeforeOldControlIsReleased() {
+        FollowStateStore store = new FollowStateStore();
+        UUID uuid = UUID.randomUUID();
+        FakeControl oldControl = new FakeControl(uuid);
+        FakeControl newControl = new FakeControl(uuid);
+        oldControl.onRelease = () ->
+                assertSame(newControl, store.runtimeControl(uuid).orElseThrow());
+        store.bindRuntime(uuid, oldControl);
+
+        store.bindRuntime(uuid, newControl);
+
+        assertSame(newControl, store.runtimeControl(uuid).orElseThrow());
+        assertEquals(List.of(FollowReleaseReason.RUNTIME_REPLACED), oldControl.reasons);
+        assertEquals(List.of(), newControl.reasons);
+    }
+
+    @Test
+    void differentCompanionUuidsRemainIsolated() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl first = new FakeControl(UUID.randomUUID());
+        FakeControl second = new FakeControl(UUID.randomUUID());
+        store.bindRuntime(first.companionUuid(), first);
+        store.bindRuntime(second.companionUuid(), second);
+
+        store.releaseRuntime(first.companionUuid(),
+                FollowReleaseReason.SCHEDULER_INTERRUPT);
+
+        assertEquals(1, first.reasons.size());
+        assertEquals(0, second.reasons.size());
+        assertSame(second, store.runtimeControl(second.companionUuid()).orElseThrow());
+    }
+
+    @Test
+    void releaseRuntimeRetainsBinding() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+        store.bindRuntime(control.companionUuid(), control);
+
+        store.releaseRuntime(control.companionUuid(),
+                FollowReleaseReason.FOLLOW_DISABLED);
+
+        assertSame(control, store.runtimeControl(control.companionUuid()).orElseThrow());
+        assertEquals(List.of(FollowReleaseReason.FOLLOW_DISABLED), control.reasons);
+    }
+
+    @Test
+    void removeRuntimeRemovesBeforeRelease() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+        control.onRelease = () ->
+                assertTrue(store.runtimeControl(control.companionUuid()).isEmpty());
+        store.bindRuntime(control.companionUuid(), control);
+
+        store.removeRuntime(control.companionUuid(),
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertEquals(0, store.runtimeControlCount());
+        assertEquals(List.of(FollowReleaseReason.COMPANION_REMOVED), control.reasons);
+    }
+
+    @Test
+    void missingRuntimeReleaseAndRemoveAreSafeNoOps() {
+        FollowStateStore store = new FollowStateStore();
+        UUID missing = UUID.randomUUID();
+
+        store.releaseRuntime(missing, FollowReleaseReason.FOLLOW_DISABLED);
+        store.removeRuntime(missing, FollowReleaseReason.COMPANION_REMOVED);
+
+        assertEquals(0, store.runtimeControlCount());
+        assertFalse(store.isDirty());
+    }
+
+    @Test
+    void releaseAllClearsMapBeforeReleasingEveryControl() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl first = new FakeControl(UUID.randomUUID());
+        FakeControl second = new FakeControl(UUID.randomUUID());
+        first.onRelease = () -> assertEquals(0, store.runtimeControlCount());
+        second.onRelease = () -> assertEquals(0, store.runtimeControlCount());
+        store.bindRuntime(first.companionUuid(), first);
+        store.bindRuntime(second.companionUuid(), second);
+
+        int failures = store.releaseAllRuntime(FollowReleaseReason.SERVER_STOPPING);
+
+        assertEquals(0, failures);
+        assertEquals(0, store.runtimeControlCount());
+        assertEquals(List.of(FollowReleaseReason.SERVER_STOPPING), first.reasons);
+        assertEquals(List.of(FollowReleaseReason.SERVER_STOPPING), second.reasons);
+    }
+
+    @Test
+    void releaseAllContinuesAfterOneControlThrows() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl faulty = new FakeControl(UUID.randomUUID());
+        FakeControl healthy = new FakeControl(UUID.randomUUID());
+        faulty.throwOnRelease = true;
+        store.bindRuntime(faulty.companionUuid(), faulty);
+        store.bindRuntime(healthy.companionUuid(), healthy);
+
+        int failures = store.releaseAllRuntime(FollowReleaseReason.SERVER_STOPPING);
+
+        assertEquals(1, failures);
+        assertEquals(1, faulty.reasons.size());
+        assertEquals(1, healthy.reasons.size());
+        assertEquals(0, store.runtimeControlCount());
+    }
+
+    @Test
+    void runtimeOperationsNeverMarkSavedDataDirty() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl first = new FakeControl(UUID.randomUUID());
+        FakeControl replacement = new FakeControl(first.companionUuid());
+
+        store.bindRuntime(first.companionUuid(), first);
+        store.bindRuntime(replacement.companionUuid(), replacement);
+        store.releaseRuntime(replacement.companionUuid(),
+                FollowReleaseReason.SCHEDULER_INTERRUPT);
+        store.removeRuntime(replacement.companionUuid(),
+                FollowReleaseReason.COMPANION_REMOVED);
+        store.releaseAllRuntime(FollowReleaseReason.SERVER_STOPPING);
+
+        assertFalse(store.isDirty());
+    }
+
+    @Test
+    void runtimeRegistryIsAbsentFromSavedNbt() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+        store.bindRuntime(control.companionUuid(), control);
+
+        CompoundTag saved = store.save(new CompoundTag());
+
+        assertEquals(1, saved.getAllKeys().size());
+        assertTrue(saved.contains("entries"));
+        assertFalse(saved.toString().contains(control.companionUuid().toString()));
+    }
+
+    @Test
+    void loadedStoreAlwaysStartsWithEmptyRuntimeRegistry() {
+        FollowStateStore original = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+        original.bindRuntime(control.companionUuid(), control);
+
+        FollowStateStore loaded =
+                FollowStateStore.load(original.save(new CompoundTag()));
+
+        assertEquals(0, loaded.runtimeControlCount());
+    }
+
+    @Test
+    void registryIsPerStoreInstanceRatherThanGlobal() {
+        FollowStateStore firstStore = new FollowStateStore();
+        FollowStateStore secondStore = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+
+        firstStore.bindRuntime(control.companionUuid(), control);
+
+        assertEquals(1, firstStore.runtimeControlCount());
+        assertEquals(0, secondStore.runtimeControlCount());
+    }
+
+    @Test
+    void runtimeSnapshotDelegatesWithoutRemovingBinding() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+        store.bindRuntime(control.companionUuid(), control);
+
+        FollowRuntimeSnapshot snapshot =
+                store.runtimeSnapshot(control.companionUuid(), 75L).orElseThrow();
+
+        assertEquals(control.snapshot, snapshot);
+        assertEquals(75L, control.lastSnapshotTick);
+        assertSame(control, store.runtimeControl(control.companionUuid()).orElseThrow());
+    }
+
+    @Test
+    void nullAndMismatchedBindingsAreExplicitlyRejected() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+
+        assertThrows(NullPointerException.class,
+                () -> store.bindRuntime(null, control));
+        assertThrows(NullPointerException.class,
+                () -> store.bindRuntime(control.companionUuid(), null));
+        assertThrows(IllegalArgumentException.class,
+                () -> store.bindRuntime(UUID.randomUUID(), control));
+    }
+
+    @Test
+    void deathThenRemoveOnlyReleasesTheRuntimeOnce() {
+        FollowStateStore store = new FollowStateStore();
+        FakeControl control = new FakeControl(UUID.randomUUID());
+        store.bindRuntime(control.companionUuid(), control);
+
+        store.removeRuntime(control.companionUuid(),
+                FollowReleaseReason.COMPANION_DEATH);
+        store.removeRuntime(control.companionUuid(),
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertEquals(List.of(FollowReleaseReason.COMPANION_DEATH), control.reasons);
+        assertEquals(0, store.runtimeControlCount());
+    }
+
+    @Test
+    void newRuntimeCanBindSameUuidAfterLifecycleRemoval() {
+        FollowStateStore store = new FollowStateStore();
+        UUID uuid = UUID.randomUUID();
+        FakeControl oldControl = new FakeControl(uuid);
+        FakeControl respawnedControl = new FakeControl(uuid);
+        store.bindRuntime(uuid, oldControl);
+        store.removeRuntime(uuid, FollowReleaseReason.COMPANION_DEATH);
+
+        store.bindRuntime(uuid, respawnedControl);
+
+        assertSame(respawnedControl, store.runtimeControl(uuid).orElseThrow());
+        assertEquals(1, store.runtimeControlCount());
+    }
+
+    @Test
+    void serverStoppingLeavesPersistentFollowIntentUnchanged() {
+        FollowStateStore store = new FollowStateStore();
+        UUID uuid = UUID.randomUUID();
+        FollowState intent = new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, 3.0, 6.0);
+        store.put(uuid, intent);
+        store.setDirty(false);
+        FakeControl control = new FakeControl(uuid);
+        store.bindRuntime(uuid, control);
+
+        store.releaseAllRuntime(FollowReleaseReason.SERVER_STOPPING);
+
+        assertEquals(intent, store.getOrDefault(uuid));
+        assertFalse(store.isDirty());
+        assertEquals(0, store.runtimeControlCount());
+    }
+
+    private static final class FakeControl implements FollowRuntimeControl {
+        private final UUID uuid;
+        private final List<FollowReleaseReason> reasons = new ArrayList<>();
+        private final FollowRuntimeSnapshot snapshot = new FollowRuntimeSnapshot(
+                FollowRuntimeState.DISABLED,
+                FollowWaitingReason.NONE,
+                false,
+                false,
+                false,
+                false,
+                FollowDecisions.NO_FAILED_COOLDOWN,
+                0L);
+        private Runnable onRelease = () -> {};
+        private boolean throwOnRelease;
+        private long lastSnapshotTick = Long.MIN_VALUE;
+
+        private FakeControl(UUID uuid) {
+            this.uuid = uuid;
+        }
+
+        @Override
+        public UUID companionUuid() {
+            return uuid;
+        }
+
+        @Override
+        public void release(FollowReleaseReason reason) {
+            reasons.add(reason);
+            onRelease.run();
+            if (throwOnRelease) {
+                throw new IllegalStateException("deliberate test failure");
+            }
+        }
+
+        @Override
+        public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+            lastSnapshotTick = currentGameTime;
+            return snapshot;
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateStoreRuntimeControlTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateStoreRuntimeControlTest.java
@@ -93,7 +93,7 @@ class FollowStateStoreRuntimeControlTest {
                 assertTrue(store.runtimeControl(control.companionUuid()).isEmpty());
         store.bindRuntime(control.companionUuid(), control);
 
-        store.removeRuntime(control.companionUuid(),
+        store.removeRuntime(control.companionUuid(), control,
                 FollowReleaseReason.COMPANION_REMOVED);
 
         assertEquals(0, store.runtimeControlCount());
@@ -106,7 +106,8 @@ class FollowStateStoreRuntimeControlTest {
         UUID missing = UUID.randomUUID();
 
         store.releaseRuntime(missing, FollowReleaseReason.FOLLOW_DISABLED);
-        store.removeRuntime(missing, FollowReleaseReason.COMPANION_REMOVED);
+        store.removeRuntime(
+                missing, new Object(), FollowReleaseReason.COMPANION_REMOVED);
 
         assertEquals(0, store.runtimeControlCount());
         assertFalse(store.isDirty());
@@ -157,7 +158,7 @@ class FollowStateStoreRuntimeControlTest {
         store.bindRuntime(replacement.companionUuid(), replacement);
         store.releaseRuntime(replacement.companionUuid(),
                 FollowReleaseReason.SCHEDULER_INTERRUPT);
-        store.removeRuntime(replacement.companionUuid(),
+        store.removeRuntime(replacement.companionUuid(), replacement,
                 FollowReleaseReason.COMPANION_REMOVED);
         store.releaseAllRuntime(FollowReleaseReason.SERVER_STOPPING);
 
@@ -234,9 +235,9 @@ class FollowStateStoreRuntimeControlTest {
         FakeControl control = new FakeControl(UUID.randomUUID());
         store.bindRuntime(control.companionUuid(), control);
 
-        store.removeRuntime(control.companionUuid(),
+        store.removeRuntime(control.companionUuid(), control,
                 FollowReleaseReason.COMPANION_DEATH);
-        store.removeRuntime(control.companionUuid(),
+        store.removeRuntime(control.companionUuid(), control,
                 FollowReleaseReason.COMPANION_REMOVED);
 
         assertEquals(List.of(FollowReleaseReason.COMPANION_DEATH), control.reasons);
@@ -250,7 +251,8 @@ class FollowStateStoreRuntimeControlTest {
         FakeControl oldControl = new FakeControl(uuid);
         FakeControl respawnedControl = new FakeControl(uuid);
         store.bindRuntime(uuid, oldControl);
-        store.removeRuntime(uuid, FollowReleaseReason.COMPANION_DEATH);
+        store.removeRuntime(
+                uuid, oldControl, FollowReleaseReason.COMPANION_DEATH);
 
         store.bindRuntime(uuid, respawnedControl);
 

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateStoreTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStateStoreTest.java
@@ -1,0 +1,149 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+
+class FollowStateStoreTest {
+
+    @Test
+    void roundTripsPersistedIntentAndApprovedDistanceOverrides() {
+        UUID companion = UUID.randomUUID();
+        FollowState expected = new FollowState(true, true,
+                FollowState.CURRENT_SCHEMA_VERSION, 3.25, 6.0);
+        FollowStateStore original = new FollowStateStore();
+        original.put(companion, expected);
+
+        CompoundTag encoded = original.save(new CompoundTag());
+        FollowStateStore decoded = FollowStateStore.load(encoded);
+
+        assertEquals(expected, decoded.find(companion).orElseThrow());
+        assertEquals(1, decoded.size());
+    }
+
+    @Test
+    void missingFieldsUseSafeDefaults() {
+        UUID companion = UUID.randomUUID();
+        CompoundTag entry = new CompoundTag();
+        entry.putUUID("companionUuid", companion);
+
+        FollowStateStore decoded = FollowStateStore.load(rootWith(entry));
+
+        assertEquals(FollowState.defaults(), decoded.find(companion).orElseThrow());
+        assertFalse(decoded.getOrDefault(companion).enabled());
+        assertFalse(decoded.getOrDefault(companion).manualPaused());
+    }
+
+    @Test
+    void unknownFieldsAreIgnoredAndNotWrittenBack() {
+        UUID companion = UUID.randomUUID();
+        CompoundTag entry = validEntry(companion, true, false);
+        entry.putString("futureField", "ignored");
+        entry.putUUID("ownerUuid", UUID.randomUUID());
+        CompoundTag root = rootWith(entry);
+        root.putString("futureRoot", "ignored");
+
+        FollowStateStore decoded = FollowStateStore.load(root);
+        CompoundTag rewritten = decoded.save(new CompoundTag());
+
+        assertTrue(decoded.getOrDefault(companion).enabled());
+        assertEquals(Set.of("entries"), rewritten.getAllKeys());
+        assertFalse(rewritten.toString().contains("futureField"));
+        assertFalse(rewritten.toString().toLowerCase().contains("owner"));
+    }
+
+    @Test
+    void malformedEntryDoesNotDiscardOtherCompanions() {
+        UUID first = UUID.randomUUID();
+        UUID malformed = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+
+        CompoundTag bad = validEntry(malformed, true, false);
+        bad.putString("enabled", "not-a-boolean");
+        FollowStateStore decoded = FollowStateStore.load(rootWith(
+                validEntry(first, true, false),
+                bad,
+                validEntry(second, false, true)));
+
+        assertEquals(2, decoded.size());
+        assertTrue(decoded.getOrDefault(first).enabled());
+        assertTrue(decoded.getOrDefault(second).manualPaused());
+        assertTrue(decoded.find(malformed).isEmpty());
+    }
+
+    @Test
+    void malformedTopLevelAndEmptyFirstLoadFallBackToEmptyStore() {
+        FollowStateStore empty = FollowStateStore.load(new CompoundTag());
+        assertEquals(0, empty.size());
+        assertEquals(FollowState.defaults(), empty.getOrDefault(UUID.randomUUID()));
+
+        CompoundTag malformed = new CompoundTag();
+        malformed.putString("entries", "not-a-list");
+        assertEquals(0, FollowStateStore.load(malformed).size());
+    }
+
+    @Test
+    void everyStateMutationMarksSavedDataDirty() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        assertFalse(store.isDirty());
+
+        store.setEnabled(companion, true);
+        assertTrue(store.isDirty());
+
+        store.setDirty(false);
+        store.setManualPaused(companion, true);
+        assertTrue(store.isDirty());
+
+        store.setDirty(false);
+        store.setDistanceOverrides(companion, 3.0, 5.5);
+        assertTrue(store.isDirty());
+
+        store.setDirty(false);
+        store.remove(companion);
+        assertTrue(store.isDirty());
+    }
+
+    @Test
+    void savedDataSchemaIsIndependentFromExistingNumenData() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.setEnabled(companion, true);
+
+        CompoundTag encoded = store.save(new CompoundTag());
+
+        assertEquals("numen_auto_follow", FollowStateStore.DATA_NAME);
+        assertNotEquals("numen_companions", FollowStateStore.DATA_NAME);
+        assertEquals(Set.of("entries"), encoded.getAllKeys());
+        assertFalse(encoded.toString().contains("NumenOwner"));
+        assertFalse(encoded.toString().toLowerCase().contains("owner"));
+    }
+
+    private static CompoundTag validEntry(UUID uuid, boolean enabled, boolean manualPaused) {
+        CompoundTag entry = new CompoundTag();
+        entry.putUUID("companionUuid", uuid);
+        entry.putBoolean("enabled", enabled);
+        entry.putBoolean("manualPaused", manualPaused);
+        entry.putInt("schemaVersion", FollowState.CURRENT_SCHEMA_VERSION);
+        return entry;
+    }
+
+    private static CompoundTag rootWith(CompoundTag... values) {
+        ListTag entries = new ListTag();
+        for (CompoundTag value : values) {
+            entries.add(value);
+        }
+        CompoundTag root = new CompoundTag();
+        root.put("entries", entries);
+        return root;
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStatusTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStatusTest.java
@@ -1,0 +1,222 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class FollowStatusTest {
+
+    private static final FollowConfig CONFIG = new FollowConfig(
+            2.0, 4.0, 9.0, 20.0, 50.0, 240L,
+            false, false, false, false, false);
+
+    @Test
+    void existingRuntimeMapsCompleteSnapshot() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.of(13.0));
+        fixture.store.bindRuntime(fixture.uuid, new FixedControl(
+                fixture.uuid,
+                new FollowRuntimeSnapshot(
+                        FollowRuntimeState.FOLLOWING,
+                        FollowWaitingReason.NONE,
+                        true, true, true, true, 250L, 200L)));
+
+        FollowStatus status = fixture.status();
+
+        assertTrue(status.runtimeAvailable());
+        assertEquals(FollowRuntimeState.FOLLOWING, status.runtimeState());
+        assertTrue(status.following());
+        assertTrue(status.navigationActive());
+        assertTrue(status.sprintAllowed());
+        assertTrue(status.catchingUp());
+        assertEquals(200L, status.remainingCooldownTicks());
+    }
+
+    @Test
+    void missingRuntimeDoesNotCreateOrBindOne() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.of(8.0));
+
+        FollowStatus status = fixture.status();
+
+        assertFalse(status.runtimeAvailable());
+        assertEquals(0, fixture.store.runtimeControlCount());
+    }
+
+    @Test
+    void missingRuntimeDerivesDisabledState() {
+        assertEquals(FollowRuntimeState.DISABLED,
+                fixture(FollowState.defaults(), OptionalDouble.of(8.0))
+                        .status().runtimeState());
+    }
+
+    @Test
+    void missingRuntimeDerivesManualPauseState() {
+        FollowState paused = new FollowState(
+                true, true, FollowState.CURRENT_SCHEMA_VERSION, null, null);
+
+        FollowStatus status =
+                fixture(paused, OptionalDouble.of(8.0)).status();
+
+        assertEquals(FollowRuntimeState.MANUALLY_PAUSED, status.runtimeState());
+    }
+
+    @Test
+    void missingRuntimeEnabledStateUsesDocumentedConservativeWaitingState() {
+        FollowStatus status =
+                fixture(enabled(), OptionalDouble.of(8.0)).status();
+
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, status.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_INVALID, status.waitingReason());
+    }
+
+    @Test
+    void statusCarriesTrueThreeDimensionalDistance() {
+        double distance =
+                FollowDecisions.distance3d(0.0, 0.0, 0.0, 3.0, 4.0, 12.0);
+        FollowStatus status =
+                fixture(enabled(), OptionalDouble.of(distance)).status();
+
+        assertEquals(13.0, status.distance().orElseThrow());
+    }
+
+    @Test
+    void ownerOfflineHasUnavailableDistanceAndExplicitReason() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.empty());
+        fixture.subject = new FollowService.Subject(
+                fixture.uuid, "Numen", true, true, false, false, false,
+                OptionalDouble.empty(), 50L);
+
+        FollowStatus status = fixture.status();
+
+        assertFalse(status.ownerOnline());
+        assertTrue(status.distance().isEmpty());
+        assertEquals(FollowWaitingReason.OWNER_OFFLINE, status.waitingReason());
+    }
+
+    @Test
+    void otherDimensionHasUnavailableDistanceAndExplicitReason() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.empty());
+        fixture.subject = new FollowService.Subject(
+                fixture.uuid, "Numen", true, true, true, true, false,
+                OptionalDouble.empty(), 50L);
+
+        FollowStatus status = fixture.status();
+
+        assertFalse(status.sameDimension());
+        assertTrue(status.distance().isEmpty());
+        assertEquals(
+                FollowWaitingReason.OWNER_OTHER_DIMENSION,
+                status.waitingReason());
+    }
+
+    @Test
+    void negativeCooldownCanNeverEscapeSnapshotOrStatus() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.of(8.0));
+        fixture.store.bindRuntime(fixture.uuid, new FixedControl(
+                fixture.uuid,
+                new FollowRuntimeSnapshot(
+                        FollowRuntimeState.FAILED_COOLDOWN,
+                        FollowWaitingReason.NONE,
+                        true, false, false, false, 1L, -5L)));
+
+        assertEquals(0L, fixture.status().remainingCooldownTicks());
+    }
+
+    @Test
+    void effectiveCompanionOverridesAndGlobalThresholdsAreReported() {
+        FollowState override = new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, 2.5, 6.5);
+
+        FollowStatus status =
+                fixture(override, OptionalDouble.of(8.0)).status();
+
+        assertEquals(2.5, status.effectiveStopDistance());
+        assertEquals(6.5, status.effectiveStartDistance());
+        assertEquals(9.0, status.sprintDistance());
+        assertEquals(20.0, status.catchUpDistance());
+        assertEquals(50.0, status.lostDistance());
+        assertEquals(240L, status.failedCooldownTicks());
+    }
+
+    @Test
+    void invalidOverridePairFallsBackToGlobalThresholds() {
+        FollowState override = new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, 2.5, 9.5);
+
+        FollowStatus status =
+                fixture(override, OptionalDouble.of(8.0)).status();
+
+        assertEquals(2.0, status.effectiveStopDistance());
+        assertEquals(4.0, status.effectiveStartDistance());
+    }
+
+    @Test
+    void formattingIsReadOnlyAndDoesNotExposeAnyOwnerUuid() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.of(8.0));
+        fixture.store.setDirty(false);
+        FollowStatus before = fixture.status();
+
+        String text = before.compactText();
+        FollowStatus after = fixture.status();
+
+        assertEquals(before, after);
+        assertFalse(fixture.store.isDirty());
+        assertFalse(text.toLowerCase().contains("uuid"));
+        assertTrue(text.contains("thresholds"));
+        assertTrue(text.contains("distance=8.00"));
+    }
+
+    @Test
+    void statusQueryNeverMutatesPersistentState() {
+        Fixture fixture = fixture(enabled(), OptionalDouble.of(8.0));
+        FollowState before = fixture.store.getOrDefault(fixture.uuid);
+        fixture.store.setDirty(false);
+
+        fixture.status();
+
+        assertEquals(before, fixture.store.getOrDefault(fixture.uuid));
+        assertFalse(fixture.store.isDirty());
+    }
+
+    private static Fixture fixture(
+            FollowState state, OptionalDouble distance) {
+        Fixture fixture = new Fixture();
+        fixture.store.put(fixture.uuid, state);
+        fixture.subject = new FollowService.Subject(
+                fixture.uuid, "Numen", true, true, true, true, true,
+                distance, 50L);
+        return fixture;
+    }
+
+    private static FollowState enabled() {
+        return new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, null, null);
+    }
+
+    private static final class Fixture {
+        final UUID uuid = UUID.randomUUID();
+        final FollowStateStore store = new FollowStateStore();
+        FollowService.Subject subject;
+
+        FollowStatus status() {
+            return FollowService.status(store, subject, CONFIG);
+        }
+    }
+
+    private record FixedControl(
+            UUID companionUuid,
+            FollowRuntimeSnapshot value) implements FollowRuntimeControl {
+
+        @Override
+        public void release(FollowReleaseReason reason) {}
+
+        @Override
+        public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+            return value;
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/FollowStatusWithoutRuntimeTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/FollowStatusWithoutRuntimeTest.java
@@ -1,0 +1,98 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.reload;
+import static com.dwinovo.numen.core.follow.FollowStage7ATestSupport.state;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FollowStatusWithoutRuntimeTest {
+
+    private static final FollowConfig CONFIG = new FollowConfig(
+            2.0, 4.0, 9.0, 20.0, 50.0, 240L,
+            false, false, false, false, false);
+
+    @ParameterizedTest
+    @ValueSource(doubles = {50.0, 50.000001})
+    void lostDistanceAndBeyondUseTooFarWithoutCreatingRuntime(
+            double distance) {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.put(companion, state(true, false, null, null));
+        store.setDirty(false);
+
+        FollowStatus status = FollowService.status(
+                store,
+                FollowStage7ATestSupport.subject(
+                        companion, true, true, true, true,
+                        OptionalDouble.of(distance), 100L),
+                CONFIG);
+
+        assertFalse(status.runtimeAvailable());
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER,
+                status.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_TOO_FAR,
+                status.waitingReason());
+        assertEquals(distance, status.distance().orElseThrow());
+        assertEquals(0, store.runtimeControlCount());
+        assertFalse(store.isDirty());
+    }
+
+    @Test
+    void reloadedOverrideUsesCurrentConfigWithoutBindingRuntime() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore original = new FollowStateStore();
+        original.put(companion, state(true, false, 2.5, 6.5));
+        FollowStateStore loaded = reload(original);
+        loaded.setDirty(false);
+
+        FollowStatus status = FollowService.status(
+                loaded,
+                FollowStage7ATestSupport.subject(
+                        companion, true, true, true, true,
+                        OptionalDouble.of(8.0), 100L),
+                CONFIG);
+
+        assertFalse(status.runtimeAvailable());
+        assertEquals(2.5, status.effectiveStopDistance());
+        assertEquals(6.5, status.effectiveStartDistance());
+        assertEquals(9.0, status.sprintDistance());
+        assertEquals(20.0, status.catchUpDistance());
+        assertEquals(50.0, status.lostDistance());
+        assertEquals(240L, status.failedCooldownTicks());
+        assertEquals(0, loaded.runtimeControlCount());
+        assertFalse(loaded.isDirty());
+    }
+
+    @Test
+    void reloadedOfflineOwnerKeepsDistanceUnavailableAndRuntimeAbsent() {
+        UUID companion = UUID.randomUUID();
+        FollowStateStore original = new FollowStateStore();
+        original.put(companion, state(true, false, null, null));
+        FollowStateStore loaded = reload(original);
+        loaded.setDirty(false);
+
+        FollowStatus status = FollowService.status(
+                loaded,
+                FollowStage7ATestSupport.subject(
+                        companion, true, false, false, false,
+                        OptionalDouble.empty(), 100L),
+                CONFIG);
+
+        assertFalse(status.runtimeAvailable());
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER,
+                status.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_OFFLINE,
+                status.waitingReason());
+        assertTrue(status.distance().isEmpty());
+        assertEquals(0, loaded.runtimeControlCount());
+        assertFalse(loaded.isDirty());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainCooldownTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainCooldownTest.java
@@ -1,0 +1,232 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.enabled;
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.snapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+
+import org.junit.jupiter.api.Test;
+
+class OwnerFollowChainCooldownTest {
+
+    @Test
+    void failedNavigationSetsDeadlineFromSnapshotGameTime() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN, view.runtimeState());
+        assertEquals(FollowWaitingReason.NONE, view.waitingReason());
+        assertEquals(150L, view.failedUntilTick());
+        assertEquals(100L, harness.chain.remainingCooldownTicks(50L));
+        assertFalse(view.sprintAllowed());
+        assertFalse(view.catchingUp());
+    }
+
+    @Test
+    void failedNavigationReleasesControlAndDoesNotCreateSecondNavInSameTick() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+
+        assertEquals(1, harness.factory.created.size());
+        assertEquals(1, harness.factory.last().ticks);
+        assertEquals(1, harness.factory.last().stops);
+        assertEquals(1, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void tickBeforeDeadlineDoesNotCreateOrTickNavigation() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(8.0, 149L);
+        int previousTicks = harness.factory.last().ticks;
+
+        harness.chain.tick(null);
+
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN,
+                harness.chain.runtimeView().runtimeState());
+        assertEquals(1, harness.factory.created.size());
+        assertEquals(previousTicks, harness.factory.last().ticks);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void priorityBeforeDeadlineIsNegativeInfinity() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(8.0, 149L);
+
+        float priority = harness.chain.getPriority(null);
+
+        assertEquals(Float.NEGATIVE_INFINITY, priority);
+        assertEquals(1L, harness.chain.remainingCooldownTicks(149L));
+    }
+
+    @Test
+    void exactDeadlineAllowsRetryWithOneNewNavigation() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(8.0, 150L);
+        harness.factory.nextStatus = PlayerNav.Status.RUNNING;
+
+        harness.chain.tick(null);
+
+        assertEquals(2, harness.factory.created.size());
+        assertEquals(1, harness.factory.last().ticks);
+        assertTrue(harness.chain.hasNavigation());
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                harness.chain.runtimeView().runtimeState());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                harness.chain.runtimeView().failedUntilTick());
+    }
+
+    @Test
+    void tickAfterDeadlineAlsoAllowsRetry() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(8.0, 151L);
+        harness.factory.nextStatus = PlayerNav.Status.RUNNING;
+
+        harness.chain.tick(null);
+
+        assertEquals(2, harness.factory.created.size());
+        assertTrue(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void repeatedFailureResetsDeadlineFromRetryTick() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(8.0, 150L);
+        harness.factory.nextStatus = PlayerNav.Status.FAILED;
+
+        harness.chain.tick(null);
+
+        assertEquals(2, harness.factory.created.size());
+        assertEquals(250L, harness.chain.runtimeView().failedUntilTick());
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN,
+                harness.chain.runtimeView().runtimeState());
+    }
+
+    @Test
+    void arrivedNavigationDoesNotEnterCooldown() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 50L));
+        harness.factory.nextStatus = PlayerNav.Status.ARRIVED;
+
+        harness.chain.tick(null);
+
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                harness.chain.runtimeView().runtimeState());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                harness.chain.runtimeView().failedUntilTick());
+    }
+
+    @Test
+    void interruptDoesNotCreateCooldownAndPreservesFollowLatch() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(12.0, 50L));
+        harness.chain.tick(null);
+
+        harness.chain.onInterrupt(null);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.FOLLOWING, view.runtimeState());
+        assertTrue(view.following());
+        assertFalse(view.sprintAllowed());
+        assertFalse(view.catchingUp());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, view.failedUntilTick());
+    }
+
+    @Test
+    void interruptDuringCooldownPreservesExistingDeadline() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+
+        harness.chain.onInterrupt(null);
+
+        assertEquals(150L, harness.chain.runtimeView().failedUntilTick());
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN,
+                harness.chain.runtimeView().runtimeState());
+    }
+
+    @Test
+    void ownerOfflineClearsOldCooldown() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = snapshot(enabled(), true, true, false,
+                false, false, Double.NaN, 60L);
+
+        harness.chain.getPriority(null);
+
+        assertEquals(FollowWaitingReason.OWNER_OFFLINE,
+                harness.chain.runtimeView().waitingReason());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                harness.chain.runtimeView().failedUntilTick());
+    }
+
+    @Test
+    void stopDistanceClearsOldCooldown() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(3.0, 60L);
+
+        harness.chain.getPriority(null);
+
+        assertEquals(FollowRuntimeState.IDLE_NEAR_OWNER,
+                harness.chain.runtimeView().runtimeState());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                harness.chain.runtimeView().failedUntilTick());
+    }
+
+    @Test
+    void lostDistanceUsesWaitingStateAndClearsOldCooldown() {
+        OwnerFollowChainTestHarness harness = failedAt(50L);
+        harness.access.snapshot = activeAt(64.0, 60L);
+
+        harness.chain.getPriority(null);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, view.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_TOO_FAR, view.waitingReason());
+        assertNotEquals(FollowRuntimeState.FAILED_COOLDOWN, view.runtimeState());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, view.failedUntilTick());
+    }
+
+    @Test
+    void twoChainsKeepFailureDeadlinesIndependent() {
+        OwnerFollowChainTestHarness first = failedAt(50L);
+        OwnerFollowChainTestHarness second =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 50L));
+        second.factory.nextStatus = PlayerNav.Status.RUNNING;
+        second.chain.tick(null);
+
+        assertEquals(150L, first.chain.runtimeView().failedUntilTick());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                second.chain.runtimeView().failedUntilTick());
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN,
+                first.chain.runtimeView().runtimeState());
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                second.chain.runtimeView().runtimeState());
+    }
+
+    @Test
+    void cooldownDoesNotMutateFollowIntent() {
+        FollowState state = enabled();
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(snapshot(state, true, true, true,
+                        true, true, 8.0, 50L));
+        harness.factory.nextStatus = PlayerNav.Status.FAILED;
+
+        harness.chain.tick(null);
+
+        assertSame(state, harness.access.snapshot.state());
+        assertEquals(enabled(), harness.access.snapshot.state());
+        assertEquals(150L, harness.chain.runtimeView().failedUntilTick());
+    }
+
+    private static OwnerFollowChainTestHarness failedAt(long gameTime) {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, gameTime));
+        harness.factory.nextStatus = PlayerNav.Status.FAILED;
+        harness.chain.tick(null);
+        return harness;
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainCooldownTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainCooldownTest.java
@@ -19,7 +19,7 @@ class OwnerFollowChainCooldownTest {
     void failedNavigationSetsDeadlineFromSnapshotGameTime() {
         OwnerFollowChainTestHarness harness = failedAt(50L);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.FAILED_COOLDOWN, view.runtimeState());
         assertEquals(FollowWaitingReason.NONE, view.waitingReason());
         assertEquals(150L, view.failedUntilTick());
@@ -130,7 +130,7 @@ class OwnerFollowChainCooldownTest {
 
         harness.chain.onInterrupt(null);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.FOLLOWING, view.runtimeState());
         assertTrue(view.following());
         assertFalse(view.sprintAllowed());
@@ -183,7 +183,7 @@ class OwnerFollowChainCooldownTest {
 
         harness.chain.getPriority(null);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, view.runtimeState());
         assertEquals(FollowWaitingReason.OWNER_TOO_FAR, view.waitingReason());
         assertNotEquals(FollowRuntimeState.FAILED_COOLDOWN, view.runtimeState());

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainDecisionTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainDecisionTest.java
@@ -1,0 +1,209 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dwinovo.numen.core.pathing.goal.GoalCompiler;
+
+import net.minecraft.core.BlockPos;
+
+import org.junit.jupiter.api.Test;
+
+class OwnerFollowChainDecisionTest {
+
+    @Test
+    void priorityIsExactlyMinusTwo() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(activeAt(5.5), false);
+
+        assertEquals(-2.0f, OwnerFollowChain.PRIORITY);
+        assertEquals(OwnerFollowChain.PRIORITY, decision.priority());
+    }
+
+    @Test
+    void disabledStateIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(new FollowState(false, false, 1, null, null),
+                        true, true, true, true, true, 8.0),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void manualPauseIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(new FollowState(true, true, 1, null, null),
+                        true, true, true, true, true, 8.0),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void missingOwnerUuidIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(enabled(), true, false, false, false, false, Double.NaN),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void unresolvedOrOfflineOwnerIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(enabled(), true, true, false, false, false, Double.NaN),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void deadOwnerIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(enabled(), true, true, true, false, false, Double.NaN),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void invalidOrDeadCompanionIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(enabled(), false, true, true, true, true, 8.0),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void differentLevelIsDormantAndClearsLatch() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(enabled(), true, true, true, true, false, Double.NaN),
+                true);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void distanceAtOrBelowStopClosesLatch() {
+        assertDormant(OwnerFollowChain.decide(activeAt(3.0), true));
+        assertDormant(OwnerFollowChain.decide(activeAt(2.99), true));
+    }
+
+    @Test
+    void distanceAtOrAboveStartOpensLatch() {
+        assertActive(OwnerFollowChain.decide(activeAt(5.5), false));
+        assertActive(OwnerFollowChain.decide(activeAt(5.51), false));
+    }
+
+    @Test
+    void hysteresisBandRetainsPreviousLatchValue() {
+        assertActive(OwnerFollowChain.decide(activeAt(4.0), true));
+        assertDormant(OwnerFollowChain.decide(activeAt(4.0), false));
+    }
+
+    @Test
+    void verticalSeparationUsesThreeDimensionalEuclideanDistance() {
+        double distance = OwnerFollowChain.distance3d(10.0, 64.0, -4.0,
+                10.0, 69.5, -4.0);
+
+        assertEquals(5.5, distance, 1.0e-9);
+        assertActive(OwnerFollowChain.decide(activeAt(distance), false));
+    }
+
+    @Test
+    void validOverridePairReplacesBothDefaults() {
+        FollowState overridden = new FollowState(true, false, 1, 4.0, 7.0);
+
+        OwnerFollowChain.Decision stopped = OwnerFollowChain.decide(
+                snapshot(overridden, true, true, true, true, true, 4.0), true);
+        OwnerFollowChain.Decision started = OwnerFollowChain.decide(
+                snapshot(overridden, true, true, true, true, true, 7.0), false);
+
+        assertEquals(new OwnerFollowChain.Distances(4.0, 7.0), stopped.distances());
+        assertDormant(stopped);
+        assertActive(started);
+    }
+
+    @Test
+    void everyInvalidOrPartialOverridePairFallsBackTogether() {
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(null, 7.0));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(4.0, null));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(Double.NaN, 7.0));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(4.0, Double.NaN));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(
+                Double.POSITIVE_INFINITY, 7.0));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(
+                4.0, Double.NEGATIVE_INFINITY));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(-1.0, 7.0));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(4.0, 0.0));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(7.0, 7.0));
+        assertDefaultDistances(OwnerFollowChain.resolveDistances(8.0, 7.0));
+    }
+
+    @Test
+    void nonFiniteMeasuredDistanceIsDormant() {
+        assertDormant(OwnerFollowChain.decide(activeAt(Double.NaN), true));
+        assertDormant(OwnerFollowChain.decide(activeAt(Double.POSITIVE_INFINITY), true));
+    }
+
+    @Test
+    void defaultFollowStateLeavesChainDormant() {
+        OwnerFollowChain.Decision decision = OwnerFollowChain.decide(
+                snapshot(FollowState.defaults(), true, true, true, true, true, 20.0),
+                false);
+
+        assertDormant(decision);
+    }
+
+    @Test
+    void registrationOrderIsExactlySixty() {
+        assertEquals(60, OwnerFollowChain.REGISTRATION_ORDER);
+    }
+
+    @Test
+    void navigationGoalUsesGoalCompilerNearSemantics() {
+        BlockPos center = new BlockPos(12, 70, -5);
+        GoalCompiler.Compiled compiled = OwnerFollowChain.compileNearGoal(center, 3.0);
+
+        assertEquals(center, compiled.goal().center());
+        assertTrue(compiled.goal().isAt(center.offset(3, 1, 0)));
+        assertFalse(compiled.goal().isAt(center.offset(4, 0, 0)));
+    }
+
+    private static FollowState enabled() {
+        return new FollowState(true, false, FollowState.CURRENT_SCHEMA_VERSION, null, null);
+    }
+
+    private static OwnerFollowChain.Snapshot activeAt(double distance) {
+        return snapshot(enabled(), true, true, true, true, true, distance);
+    }
+
+    private static OwnerFollowChain.Snapshot snapshot(
+            FollowState state,
+            boolean companionValid,
+            boolean ownerUuidPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameLevel,
+            double distance) {
+        return new OwnerFollowChain.Snapshot(state, companionValid, ownerUuidPresent,
+                ownerOnline, ownerValid, sameLevel, distance);
+    }
+
+    private static void assertActive(OwnerFollowChain.Decision decision) {
+        assertTrue(decision.following());
+        assertEquals(OwnerFollowChain.PRIORITY, decision.priority());
+    }
+
+    private static void assertDormant(OwnerFollowChain.Decision decision) {
+        assertFalse(decision.following());
+        assertEquals(Float.NEGATIVE_INFINITY, decision.priority());
+    }
+
+    private static void assertDefaultDistances(OwnerFollowChain.Distances distances) {
+        assertEquals(OwnerFollowChain.DEFAULT_STOP_DISTANCE, distances.stop());
+        assertEquals(OwnerFollowChain.DEFAULT_START_DISTANCE, distances.start());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainExternalReleaseTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainExternalReleaseTest.java
@@ -1,0 +1,243 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+
+class OwnerFollowChainExternalReleaseTest {
+
+    @Test
+    void ownerFollowChainImplementsRuntimeControl() {
+        assertInstanceOf(FollowRuntimeControl.class, new OwnerFollowChain());
+    }
+
+    @Test
+    void snapshotIsAStableValueAndDoesNotMutateRuntime() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(12.0, 40L));
+        harness.chain.tick(null);
+
+        FollowRuntimeSnapshot first = harness.chain.snapshot(40L);
+        FollowRuntimeSnapshot second = harness.chain.snapshot(40L);
+
+        assertEquals(first, second);
+        assertEquals(first, harness.chain.runtimeView());
+        assertTrue(first.navigationActive());
+    }
+
+    @Test
+    void snapshotClampsNegativeRemainingCooldownToZero() {
+        FollowRuntimeSnapshot snapshot = new FollowRuntimeSnapshot(
+                FollowRuntimeState.DISABLED,
+                FollowWaitingReason.NONE,
+                false, false, false, false, -1L, -25L);
+
+        assertEquals(0L, snapshot.remainingCooldownTicks());
+    }
+
+    @Test
+    void followDisabledStopsAndPublishesDisabledState() {
+        OwnerFollowChainTestHarness harness = activeHarness();
+        OwnerFollowChainTestHarness.FakeNavigation navigation = harness.factory.last();
+
+        harness.chain.release(FollowReleaseReason.FOLLOW_DISABLED);
+
+        assertEquals(1, navigation.stops);
+        assertEquals(0, harness.halt.calls);
+        assertReleased(harness.chain.snapshot(10L),
+                FollowRuntimeState.DISABLED, FollowWaitingReason.NONE);
+    }
+
+    @Test
+    void manualPauseStopsAndPublishesPausedState() {
+        OwnerFollowChainTestHarness harness = activeHarness();
+
+        harness.chain.release(FollowReleaseReason.MANUAL_PAUSE);
+
+        assertEquals(1, harness.factory.last().stops);
+        assertEquals(0, harness.halt.calls);
+        assertReleased(harness.chain.snapshot(10L),
+                FollowRuntimeState.MANUALLY_PAUSED, FollowWaitingReason.NONE);
+    }
+
+    @Test
+    void companionDeathClearsNavigationLatchAndCooldown() {
+        OwnerFollowChainTestHarness harness = failedHarness();
+
+        harness.chain.release(FollowReleaseReason.COMPANION_DEATH);
+
+        FollowRuntimeSnapshot snapshot = harness.chain.snapshot(10L);
+        assertReleased(snapshot, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.COMPANION_NOT_ACTIVE);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, snapshot.failedUntilTick());
+    }
+
+    @Test
+    void companionRemovalClearsNavigationLatchAndCooldown() {
+        OwnerFollowChainTestHarness harness = failedHarness();
+
+        harness.chain.release(FollowReleaseReason.COMPANION_REMOVED);
+
+        FollowRuntimeSnapshot snapshot = harness.chain.snapshot(10L);
+        assertReleased(snapshot, FollowRuntimeState.WAITING_FOR_OWNER,
+                FollowWaitingReason.COMPANION_NOT_ACTIVE);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, snapshot.failedUntilTick());
+    }
+
+    @Test
+    void serverStoppingClearsNavigationLatchAndCooldown() {
+        OwnerFollowChainTestHarness harness = failedHarness();
+
+        harness.chain.release(FollowReleaseReason.SERVER_STOPPING);
+
+        FollowRuntimeSnapshot snapshot = harness.chain.snapshot(10L);
+        assertReleased(snapshot, FollowRuntimeState.DISABLED, FollowWaitingReason.NONE);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, snapshot.failedUntilTick());
+    }
+
+    @Test
+    void runtimeReplacementClearsOldRuntime() {
+        OwnerFollowChainTestHarness harness = activeHarness();
+
+        harness.chain.release(FollowReleaseReason.RUNTIME_REPLACED);
+
+        assertEquals(1, harness.factory.last().stops);
+        assertReleased(harness.chain.snapshot(10L),
+                FollowRuntimeState.DISABLED, FollowWaitingReason.NONE);
+    }
+
+    @Test
+    void repeatedExternalReleaseIsIdempotentForNavigation() {
+        OwnerFollowChainTestHarness harness = activeHarness();
+        OwnerFollowChainTestHarness.FakeNavigation navigation = harness.factory.last();
+
+        harness.chain.release(FollowReleaseReason.FOLLOW_DISABLED);
+        harness.chain.release(FollowReleaseReason.FOLLOW_DISABLED);
+
+        assertEquals(1, navigation.stops);
+        assertEquals(0, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void unboundControlReleaseWithNoNavigationIsSafe() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+
+        harness.chain.release(FollowReleaseReason.SERVER_STOPPING);
+        harness.chain.release(FollowReleaseReason.SERVER_STOPPING);
+
+        assertFalse(harness.chain.snapshot(10L).navigationActive());
+        assertEquals(0, harness.halt.calls);
+    }
+
+    @Test
+    void releasedNavigationCannotBeTickedAgainByChain() {
+        OwnerFollowChainTestHarness harness = activeHarness();
+        OwnerFollowChainTestHarness.FakeNavigation oldNavigation = harness.factory.last();
+        harness.chain.release(FollowReleaseReason.SCHEDULER_INTERRUPT);
+
+        harness.chain.tick(null);
+
+        assertEquals(1, oldNavigation.ticks);
+        assertEquals(1, oldNavigation.stops);
+        assertEquals(2, harness.factory.created.size());
+        assertNotSame(oldNavigation, harness.factory.last());
+    }
+
+    @Test
+    void schedulerInterruptPreservesFailureDeadlineWithoutCreatingOne() {
+        OwnerFollowChainTestHarness active = activeHarness();
+        active.chain.release(FollowReleaseReason.SCHEDULER_INTERRUPT);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                active.chain.snapshot(10L).failedUntilTick());
+
+        OwnerFollowChainTestHarness failed = failedHarness();
+        long deadline = failed.chain.snapshot(10L).failedUntilTick();
+        failed.chain.release(FollowReleaseReason.SCHEDULER_INTERRUPT);
+        assertEquals(deadline, failed.chain.snapshot(10L).failedUntilTick());
+    }
+
+    @Test
+    void schedulerInterruptPreservesLatchAndAllowsFreshNavigationResume() {
+        OwnerFollowChainTestHarness harness = activeHarness();
+        OwnerFollowChainTestHarness.FakeNavigation oldNavigation = harness.factory.last();
+        assertTrue(harness.chain.snapshot(10L).following());
+
+        harness.chain.release(FollowReleaseReason.SCHEDULER_INTERRUPT);
+        assertTrue(harness.chain.snapshot(10L).following());
+        harness.chain.tick(null);
+
+        assertEquals(2, harness.factory.created.size());
+        assertNotSame(oldNavigation, harness.factory.last());
+        assertTrue(harness.chain.snapshot(10L).following());
+    }
+
+    @Test
+    void allExternalReasonsClearSprintAndCatchUp() {
+        for (FollowReleaseReason reason : FollowReleaseReason.values()) {
+            if (reason == FollowReleaseReason.SCHEDULER_INTERRUPT
+                    || reason == FollowReleaseReason.INTERNAL_STATE_CHANGE) {
+                continue;
+            }
+            OwnerFollowChainTestHarness harness =
+                    new OwnerFollowChainTestHarness(activeAt(24.0, 10L));
+            harness.chain.tick(null);
+            assertTrue(harness.chain.snapshot(10L).sprintAllowed());
+            assertTrue(harness.chain.snapshot(10L).catchingUp());
+
+            harness.chain.release(reason);
+
+            assertFalse(harness.chain.snapshot(10L).sprintAllowed());
+            assertFalse(harness.chain.snapshot(10L).catchingUp());
+        }
+    }
+
+    @Test
+    void externalReleaseDoesNotMutateFollowIntentSnapshot() {
+        OwnerFollowChain.Snapshot intentSnapshot = activeAt(8.0, 10L);
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(intentSnapshot);
+
+        harness.chain.tick(null);
+        harness.chain.release(FollowReleaseReason.COMPANION_DEATH);
+
+        assertEquals(intentSnapshot, harness.access.snapshot);
+        assertTrue(harness.access.snapshot.state().enabled());
+        assertFalse(harness.access.snapshot.state().manualPaused());
+    }
+
+    private static OwnerFollowChainTestHarness activeHarness() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.chain.tick(null);
+        return harness;
+    }
+
+    private static OwnerFollowChainTestHarness failedHarness() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.factory.nextStatus = PlayerNav.Status.FAILED;
+        harness.chain.tick(null);
+        return harness;
+    }
+
+    private static void assertReleased(
+            FollowRuntimeSnapshot snapshot,
+            FollowRuntimeState expectedState,
+            FollowWaitingReason expectedReason) {
+        assertEquals(expectedState, snapshot.runtimeState());
+        assertEquals(expectedReason, snapshot.waitingReason());
+        assertFalse(snapshot.navigationActive());
+        assertFalse(snapshot.following());
+        assertFalse(snapshot.sprintAllowed());
+        assertFalse(snapshot.catchingUp());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainLifecycleTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainLifecycleTest.java
@@ -1,0 +1,375 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.goal.GoalCompiler;
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.dwinovo.numen.task.ChainScheduler;
+import com.dwinovo.numen.task.TaskChain;
+
+import org.junit.jupiter.api.Test;
+
+class OwnerFollowChainLifecycleTest {
+
+    @Test
+    void chainThatDoesNotWinNeverCreatesOrTicksNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+        CountingChain explicitTask = new CountingChain(TaskChain.LLM_BASE_PRIORITY);
+
+        TaskChain winner = ChainScheduler.select(List.of(harness.chain, explicitTask), null);
+        winner.tick(null);
+
+        assertSame(explicitTask, winner);
+        assertEquals(0, harness.factory.creates);
+        assertEquals(0, harness.navigation.ticks);
+    }
+
+    @Test
+    void chainTicksNavigationOnlyAfterSchedulerSelectsIt() {
+        Harness harness = new Harness(activeAt(8.0));
+
+        TaskChain winner = ChainScheduler.select(List.of(harness.chain), null);
+        winner.tick(null);
+
+        assertSame(harness.chain, winner);
+        assertEquals(1, harness.factory.creates);
+        assertEquals(1, harness.navigation.ticks);
+    }
+
+    @Test
+    void oneChainCreatesAtMostOneNavigationAtATime() {
+        Harness harness = new Harness(activeAt(8.0));
+
+        harness.chain.tick(null);
+        harness.chain.tick(null);
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.factory.creates);
+        assertTrue(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void consecutiveWinningTicksReuseTheSameNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+
+        harness.chain.tick(null);
+        OwnerFollowChain.Navigation created = harness.factory.lastCreated;
+        harness.chain.tick(null);
+
+        assertSame(created, harness.factory.lastCreated);
+        assertEquals(2, harness.navigation.ticks);
+        assertEquals(1, harness.factory.creates);
+    }
+
+    @Test
+    void navigationReceivesTheSafeFollowContextProvider() {
+        Harness harness = new Harness(activeAt(8.0));
+
+        harness.chain.tick(null);
+
+        assertSame(FollowContextProvider.INSTANCE, harness.factory.contextProvider);
+    }
+
+    @Test
+    void navigationUsesTheDynamicOwnerGoalSupplier() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.navigation.readGoalOnTick = true;
+
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.access.goalCompiles);
+        assertEquals(OwnerFollowChain.DEFAULT_STOP_DISTANCE,
+                harness.access.lastGoalStopDistance);
+    }
+
+    @Test
+    void interruptStopsHaltsAndClearsNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.chain.tick(null);
+
+        harness.chain.onInterrupt(null);
+
+        assertEquals(1, harness.navigation.stops);
+        assertEquals(1, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void repeatedInterruptIsIdempotentAndSafe() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.chain.tick(null);
+
+        harness.chain.onInterrupt(null);
+        harness.chain.onInterrupt(null);
+
+        assertEquals(1, harness.navigation.stops);
+        assertEquals(2, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void winningTickRevalidationFailureDoesNotTickExistingNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.chain.tick(null);
+        harness.access.snapshot = snapshot(enabled(), true, true, false,
+                false, false, Double.NaN);
+
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.navigation.ticks);
+        assertEquals(1, harness.navigation.stops);
+        assertEquals(1, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void reachingStopDistanceStopsHaltsAndClearsNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.chain.tick(null);
+        harness.access.snapshot = activeAt(OwnerFollowChain.DEFAULT_STOP_DISTANCE);
+
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.navigation.ticks);
+        assertEquals(1, harness.navigation.stops);
+        assertEquals(1, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void failedNavigationStopsHaltsAndClearsNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.navigation.status = PlayerNav.Status.FAILED;
+
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.navigation.ticks);
+        assertEquals(1, harness.navigation.stops);
+        assertEquals(1, harness.halt.calls);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void arrivedNavigationRemeasuresAndDoesNotCreateSecondNavInSameTick() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.navigation.status = PlayerNav.Status.ARRIVED;
+        harness.navigation.onTick = () ->
+                harness.access.snapshot = activeAt(OwnerFollowChain.DEFAULT_STOP_DISTANCE);
+
+        harness.chain.tick(null);
+
+        assertEquals(2, harness.access.snapshots);
+        assertEquals(1, harness.factory.creates);
+        assertEquals(1, harness.navigation.ticks);
+        assertEquals(1, harness.navigation.stops);
+        assertFalse(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void arrivedOutsideStopDistanceRetainsRevalidatingNavigation() {
+        Harness harness = new Harness(activeAt(8.0));
+        harness.navigation.status = PlayerNav.Status.ARRIVED;
+
+        harness.chain.tick(null);
+
+        assertEquals(2, harness.access.snapshots);
+        assertEquals(1, harness.factory.creates);
+        assertEquals(1, harness.navigation.ticks);
+        assertEquals(0, harness.navigation.stops);
+        assertEquals(0, harness.halt.calls);
+        assertTrue(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void runningNavigationRemainsOwnedWithoutRelease() {
+        Harness harness = new Harness(activeAt(8.0));
+
+        harness.chain.tick(null);
+
+        assertEquals(0, harness.navigation.stops);
+        assertEquals(0, harness.halt.calls);
+        assertTrue(harness.chain.hasNavigation());
+    }
+
+    @Test
+    void separateChainInstancesKeepIndependentHysteresisLatches() {
+        Harness first = new Harness(activeAt(8.0));
+        Harness second = new Harness(activeAt(4.0));
+
+        assertEquals(OwnerFollowChain.PRIORITY, first.chain.getPriority(null));
+        assertEquals(Float.NEGATIVE_INFINITY, second.chain.getPriority(null));
+        assertNotSame(first.chain, second.chain);
+    }
+
+    @Test
+    void defaultDormantStateNeverCreatesNavigation() {
+        Harness harness = new Harness(snapshot(FollowState.defaults(),
+                true, true, true, true, true, 20.0));
+
+        harness.chain.tick(null);
+
+        assertEquals(0, harness.factory.creates);
+        assertEquals(0, harness.navigation.ticks);
+        assertEquals(1, harness.halt.calls);
+    }
+
+    private static FollowState enabled() {
+        return new FollowState(true, false, FollowState.CURRENT_SCHEMA_VERSION, null, null);
+    }
+
+    private static OwnerFollowChain.Snapshot activeAt(double distance) {
+        return snapshot(enabled(), true, true, true, true, true, distance);
+    }
+
+    private static OwnerFollowChain.Snapshot snapshot(
+            FollowState state,
+            boolean companionValid,
+            boolean ownerUuidPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameLevel,
+            double distance) {
+        return new OwnerFollowChain.Snapshot(state, companionValid, ownerUuidPresent,
+                ownerOnline, ownerValid, sameLevel, distance);
+    }
+
+    private static final class Harness {
+        private final FakeAccess access;
+        private final FakeNavigation navigation = new FakeNavigation();
+        private final FakeNavigationFactory factory = new FakeNavigationFactory(navigation);
+        private final FakeHalt halt = new FakeHalt();
+        private final OwnerFollowChain chain;
+
+        private Harness(OwnerFollowChain.Snapshot snapshot) {
+            access = new FakeAccess(snapshot);
+            chain = new OwnerFollowChain(access, factory, halt);
+        }
+    }
+
+    private static final class FakeAccess implements OwnerFollowChain.FollowAccess {
+        private OwnerFollowChain.Snapshot snapshot;
+        private int snapshots;
+        private int goalCompiles;
+        private double lastGoalStopDistance;
+
+        private FakeAccess(OwnerFollowChain.Snapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public OwnerFollowChain.Snapshot snapshot(NumenPlayer companion) {
+            snapshots++;
+            return snapshot;
+        }
+
+        @Override
+        public GoalCompiler.Compiled compileOwnerGoal(
+                NumenPlayer companion, double stopDistance) {
+            goalCompiles++;
+            lastGoalStopDistance = stopDistance;
+            return null;
+        }
+
+        @Override
+        public boolean isWithinStopDistance(NumenPlayer companion, double stopDistance) {
+            return snapshot.distance() <= stopDistance;
+        }
+    }
+
+    private static final class FakeNavigationFactory
+            implements OwnerFollowChain.NavigationFactory {
+        private final FakeNavigation navigation;
+        private int creates;
+        private OwnerFollowChain.Navigation lastCreated;
+        private PlayerNav.ContextProvider contextProvider;
+
+        private FakeNavigationFactory(FakeNavigation navigation) {
+            this.navigation = navigation;
+        }
+
+        @Override
+        public OwnerFollowChain.Navigation create(
+                NumenPlayer companion,
+                Supplier<GoalCompiler.Compiled> goal,
+                BooleanSupplier reached,
+                PlayerNav.ContextProvider contextProvider) {
+            creates++;
+            navigation.goal = goal;
+            navigation.reached = reached;
+            this.contextProvider = contextProvider;
+            lastCreated = navigation;
+            return navigation;
+        }
+    }
+
+    private static final class FakeNavigation implements OwnerFollowChain.Navigation {
+        private PlayerNav.Status status = PlayerNav.Status.RUNNING;
+        private int ticks;
+        private int stops;
+        private boolean readGoalOnTick;
+        private Runnable onTick = () -> {};
+        private Supplier<GoalCompiler.Compiled> goal;
+        @SuppressWarnings("unused")
+        private BooleanSupplier reached;
+
+        @Override
+        public PlayerNav.Status tick() {
+            ticks++;
+            if (readGoalOnTick) {
+                goal.get();
+            }
+            onTick.run();
+            return status;
+        }
+
+        @Override
+        public void stop() {
+            stops++;
+        }
+    }
+
+    private static final class FakeHalt implements OwnerFollowChain.HaltAction {
+        private int calls;
+
+        @Override
+        public void halt(NumenPlayer companion) {
+            calls++;
+        }
+    }
+
+    private static final class CountingChain implements TaskChain {
+        private final float priority;
+        private int ticks;
+
+        private CountingChain(float priority) {
+            this.priority = priority;
+        }
+
+        @Override
+        public float getPriority(NumenPlayer companion) {
+            return priority;
+        }
+
+        @Override
+        public void tick(NumenPlayer companion) {
+            ticks++;
+        }
+
+        @Override
+        public void onInterrupt(NumenPlayer companion) {}
+
+        @Override
+        public String name() {
+            return "counting";
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainLifecycleTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainLifecycleTest.java
@@ -301,7 +301,8 @@ class OwnerFollowChainLifecycleTest {
                 NumenPlayer companion,
                 Supplier<GoalCompiler.Compiled> goal,
                 BooleanSupplier reached,
-                PlayerNav.ContextProvider contextProvider) {
+                PlayerNav.ContextProvider contextProvider,
+                BooleanSupplier sprintAllowed) {
             creates++;
             navigation.goal = goal;
             navigation.reached = reached;

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainRuntimeTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainRuntimeTest.java
@@ -1,0 +1,253 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.enabled;
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.snapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.task.ChainScheduler;
+import com.dwinovo.numen.task.TaskChain;
+
+import org.junit.jupiter.api.Test;
+
+class OwnerFollowChainRuntimeTest {
+
+    @Test
+    void newChainStartsDisabledWithNoWaitingReasonOrNavigation() {
+        OwnerFollowChain chain = new OwnerFollowChain();
+
+        OwnerFollowChain.RuntimeView view = chain.runtimeView();
+
+        assertEquals(FollowRuntimeState.DISABLED, view.runtimeState());
+        assertEquals(FollowWaitingReason.NONE, view.waitingReason());
+        assertFalse(view.following());
+        assertFalse(view.sprintAllowed());
+        assertFalse(view.catchingUp());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN, view.failedUntilTick());
+        assertFalse(view.navigationActive());
+    }
+
+    @Test
+    void winningTickPublishesFollowingRuntimeState() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+
+        harness.chain.tick(null);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.FOLLOWING, view.runtimeState());
+        assertEquals(FollowWaitingReason.NONE, view.waitingReason());
+        assertTrue(view.following());
+        assertTrue(view.navigationActive());
+    }
+
+    @Test
+    void followNavigationReceivesSafeContextAndPerChainSprintSupplier() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+
+        harness.chain.tick(null);
+
+        assertSame(FollowContextProvider.INSTANCE, harness.factory.contextProvider);
+        assertSame(harness.factory.sprintAllowed,
+                harness.factory.last().sprintAllowed);
+        assertFalse(harness.factory.sprintAllowed.getAsBoolean());
+    }
+
+    @Test
+    void sameNavigationGateTurnsOnAtSprintThreshold() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(11.99, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        assertFalse(navigation.sprintAllowed.getAsBoolean());
+
+        harness.access.snapshot = activeAt(12.0, 11L);
+        harness.chain.tick(null);
+
+        assertSame(navigation, harness.factory.last());
+        assertEquals(1, harness.factory.created.size());
+        assertTrue(navigation.sprintAllowed.getAsBoolean());
+    }
+
+    @Test
+    void sameNavigationGateTurnsOffBelowSprintThreshold() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(12.0, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        assertTrue(navigation.sprintAllowed.getAsBoolean());
+
+        harness.access.snapshot = activeAt(11.99, 11L);
+        harness.chain.tick(null);
+
+        assertSame(navigation, harness.factory.last());
+        assertEquals(1, harness.factory.created.size());
+        assertFalse(navigation.sprintAllowed.getAsBoolean());
+    }
+
+    @Test
+    void catchUpIsOnlyABooleanModeWithinFollowing() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(24.0, 10L));
+
+        harness.chain.tick(null);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.FOLLOWING, view.runtimeState());
+        assertTrue(view.sprintAllowed());
+        assertTrue(view.catchingUp());
+    }
+
+    @Test
+    void lostDistanceImmediatelyStopsHaltsAndDoesNotCreateAnotherNavigation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+
+        harness.access.snapshot = activeAt(64.0, 11L);
+        harness.chain.tick(null);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, view.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_TOO_FAR, view.waitingReason());
+        assertEquals(1, navigation.stops);
+        assertEquals(1, harness.halt.calls);
+        assertEquals(1, harness.factory.created.size());
+        assertFalse(view.navigationActive());
+    }
+
+    @Test
+    void ownerOfflineReleasesControlAndPublishesOfflineReason() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        harness.access.snapshot = snapshot(enabled(), true, true, false,
+                false, false, Double.NaN, 11L);
+
+        harness.chain.tick(null);
+
+        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, view.runtimeState());
+        assertEquals(FollowWaitingReason.OWNER_OFFLINE, view.waitingReason());
+        assertEquals(1, navigation.stops);
+        assertFalse(view.navigationActive());
+    }
+
+    @Test
+    void arrivedWhileStillFollowingRetainsSameRevalidatingNavigation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.factory.nextStatus = PlayerNav.Status.ARRIVED;
+
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.factory.created.size());
+        assertEquals(0, harness.factory.last().stops);
+        assertTrue(harness.chain.runtimeView().navigationActive());
+        assertEquals(FollowRuntimeState.FOLLOWING,
+                harness.chain.runtimeView().runtimeState());
+    }
+
+    @Test
+    void arrivedAfterEnteringStopDistanceReleasesControlWithoutSecondNavigation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.factory.nextStatus = PlayerNav.Status.ARRIVED;
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        navigation.onTick = () ->
+                harness.access.snapshot = activeAt(3.0, 11L);
+
+        harness.chain.tick(null);
+
+        assertEquals(1, harness.factory.created.size());
+        assertEquals(1, navigation.stops);
+        assertEquals(FollowRuntimeState.IDLE_NEAR_OWNER,
+                harness.chain.runtimeView().runtimeState());
+    }
+
+    @Test
+    void twoChainsKeepRuntimeModesAndNavigationIndependent() {
+        OwnerFollowChainTestHarness first =
+                new OwnerFollowChainTestHarness(activeAt(24.0, 10L));
+        OwnerFollowChainTestHarness second =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+
+        first.chain.tick(null);
+        second.chain.tick(null);
+
+        assertNotSame(first.chain, second.chain);
+        assertNotSame(first.factory.last(), second.factory.last());
+        assertTrue(first.chain.runtimeView().catchingUp());
+        assertFalse(second.chain.runtimeView().catchingUp());
+        assertTrue(first.chain.runtimeView().sprintAllowed());
+        assertFalse(second.chain.runtimeView().sprintAllowed());
+    }
+
+    @Test
+    void lostOwnerIsRecheckedEverySchedulerEvaluation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(64.0, 10L));
+        assertEquals(Float.NEGATIVE_INFINITY, harness.chain.getPriority(null));
+
+        harness.access.snapshot = activeAt(8.0, 11L);
+
+        assertEquals(OwnerFollowChain.PRIORITY, harness.chain.getPriority(null));
+        assertEquals(2, harness.access.snapshots);
+        assertEquals(0, harness.factory.created.size());
+    }
+
+    @Test
+    void higherPrioritySchedulerWinnerInterruptsAndReleasesFollowNavigation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        TaskChain explicit = new TaskChain() {
+            @Override
+            public float getPriority(com.dwinovo.numen.entity.NumenPlayer companion) {
+                return TaskChain.LLM_BASE_PRIORITY;
+            }
+
+            @Override
+            public void tick(com.dwinovo.numen.entity.NumenPlayer companion) {}
+
+            @Override
+            public void onInterrupt(com.dwinovo.numen.entity.NumenPlayer companion) {}
+
+            @Override
+            public String name() {
+                return "explicit";
+            }
+        };
+
+        TaskChain running = harness.chain;
+        TaskChain winner = ChainScheduler.select(
+                List.of(harness.chain, explicit), null);
+        if (running != winner) {
+            running.onInterrupt(null);
+        }
+
+        assertSame(explicit, winner);
+        assertEquals(1, navigation.stops);
+        assertFalse(harness.chain.hasNavigation());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                harness.chain.runtimeView().failedUntilTick());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainRuntimeTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainRuntimeTest.java
@@ -23,7 +23,7 @@ class OwnerFollowChainRuntimeTest {
     void newChainStartsDisabledWithNoWaitingReasonOrNavigation() {
         OwnerFollowChain chain = new OwnerFollowChain();
 
-        OwnerFollowChain.RuntimeView view = chain.runtimeView();
+        FollowRuntimeSnapshot view = chain.runtimeView();
 
         assertEquals(FollowRuntimeState.DISABLED, view.runtimeState());
         assertEquals(FollowWaitingReason.NONE, view.waitingReason());
@@ -41,7 +41,7 @@ class OwnerFollowChainRuntimeTest {
 
         harness.chain.tick(null);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.FOLLOWING, view.runtimeState());
         assertEquals(FollowWaitingReason.NONE, view.waitingReason());
         assertTrue(view.following());
@@ -102,7 +102,7 @@ class OwnerFollowChainRuntimeTest {
 
         harness.chain.tick(null);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.FOLLOWING, view.runtimeState());
         assertTrue(view.sprintAllowed());
         assertTrue(view.catchingUp());
@@ -119,7 +119,7 @@ class OwnerFollowChainRuntimeTest {
         harness.access.snapshot = activeAt(64.0, 11L);
         harness.chain.tick(null);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, view.runtimeState());
         assertEquals(FollowWaitingReason.OWNER_TOO_FAR, view.waitingReason());
         assertEquals(1, navigation.stops);
@@ -140,7 +140,7 @@ class OwnerFollowChainRuntimeTest {
 
         harness.chain.tick(null);
 
-        OwnerFollowChain.RuntimeView view = harness.chain.runtimeView();
+        FollowRuntimeSnapshot view = harness.chain.runtimeView();
         assertEquals(FollowRuntimeState.WAITING_FOR_OWNER, view.runtimeState());
         assertEquals(FollowWaitingReason.OWNER_OFFLINE, view.waitingReason());
         assertEquals(1, navigation.stops);

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainTestHarness.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainTestHarness.java
@@ -17,8 +17,13 @@ final class OwnerFollowChainTestHarness {
     final OwnerFollowChain chain;
 
     OwnerFollowChainTestHarness(OwnerFollowChain.Snapshot snapshot) {
+        this(snapshot, FollowConfig.defaults());
+    }
+
+    OwnerFollowChainTestHarness(
+            OwnerFollowChain.Snapshot snapshot, FollowConfig config) {
         access = new FakeAccess(snapshot);
-        chain = new OwnerFollowChain(access, factory, halt);
+        chain = new OwnerFollowChain(access, factory, halt, config);
     }
 
     static FollowState enabled() {

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainTestHarness.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainTestHarness.java
@@ -96,6 +96,7 @@ final class OwnerFollowChainTestHarness {
             FakeNavigation navigation = new FakeNavigation(nextStatus);
             navigation.goal = goal;
             navigation.reached = reached;
+            navigation.contextProvider = contextProvider;
             navigation.sprintAllowed = sprintAllowed;
             created.add(navigation);
             this.contextProvider = contextProvider;
@@ -113,8 +114,11 @@ final class OwnerFollowChainTestHarness {
         int ticks;
         int stops;
         Runnable onTick = () -> {};
+        Runnable onStop = () -> {};
+        boolean throwOnStop;
         Supplier<GoalCompiler.Compiled> goal;
         BooleanSupplier reached;
+        PlayerNav.ContextProvider contextProvider;
         BooleanSupplier sprintAllowed;
 
         FakeNavigation(PlayerNav.Status status) {
@@ -131,15 +135,23 @@ final class OwnerFollowChainTestHarness {
         @Override
         public void stop() {
             stops++;
+            onStop.run();
+            if (throwOnStop) {
+                throw new IllegalStateException("deliberate navigation stop failure");
+            }
         }
     }
 
     static final class FakeHalt implements OwnerFollowChain.HaltAction {
         int calls;
+        boolean throwOnHalt;
 
         @Override
         public void halt(NumenPlayer companion) {
             calls++;
+            if (throwOnHalt) {
+                throw new IllegalStateException("deliberate input halt failure");
+            }
         }
     }
 }

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainTestHarness.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowChainTestHarness.java
@@ -1,0 +1,140 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.goal.GoalCompiler;
+import com.dwinovo.numen.entity.NumenPlayer;
+
+final class OwnerFollowChainTestHarness {
+
+    final FakeAccess access;
+    final FakeNavigationFactory factory = new FakeNavigationFactory();
+    final FakeHalt halt = new FakeHalt();
+    final OwnerFollowChain chain;
+
+    OwnerFollowChainTestHarness(OwnerFollowChain.Snapshot snapshot) {
+        access = new FakeAccess(snapshot);
+        chain = new OwnerFollowChain(access, factory, halt);
+    }
+
+    static FollowState enabled() {
+        return new FollowState(
+                true, false, FollowState.CURRENT_SCHEMA_VERSION, null, null);
+    }
+
+    static OwnerFollowChain.Snapshot activeAt(double distance, long gameTime) {
+        return snapshot(enabled(), true, true, true, true, true, distance, gameTime);
+    }
+
+    static OwnerFollowChain.Snapshot snapshot(
+            FollowState state,
+            boolean companionValid,
+            boolean ownerUuidPresent,
+            boolean ownerOnline,
+            boolean ownerValid,
+            boolean sameLevel,
+            double distance,
+            long gameTime) {
+        return new OwnerFollowChain.Snapshot(state, companionValid, ownerUuidPresent,
+                ownerOnline, ownerValid, sameLevel, distance, gameTime);
+    }
+
+    static final class FakeAccess implements OwnerFollowChain.FollowAccess {
+        OwnerFollowChain.Snapshot snapshot;
+        int snapshots;
+        int goalCompiles;
+        double lastGoalStopDistance;
+
+        FakeAccess(OwnerFollowChain.Snapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public OwnerFollowChain.Snapshot snapshot(NumenPlayer companion) {
+            snapshots++;
+            return snapshot;
+        }
+
+        @Override
+        public GoalCompiler.Compiled compileOwnerGoal(
+                NumenPlayer companion, double stopDistance) {
+            goalCompiles++;
+            lastGoalStopDistance = stopDistance;
+            return null;
+        }
+
+        @Override
+        public boolean isWithinStopDistance(
+                NumenPlayer companion, double stopDistance) {
+            return snapshot.distance() <= stopDistance;
+        }
+    }
+
+    static final class FakeNavigationFactory
+            implements OwnerFollowChain.NavigationFactory {
+        final List<FakeNavigation> created = new ArrayList<>();
+        PlayerNav.Status nextStatus = PlayerNav.Status.RUNNING;
+        PlayerNav.ContextProvider contextProvider;
+        BooleanSupplier sprintAllowed;
+
+        @Override
+        public OwnerFollowChain.Navigation create(
+                NumenPlayer companion,
+                Supplier<GoalCompiler.Compiled> goal,
+                BooleanSupplier reached,
+                PlayerNav.ContextProvider contextProvider,
+                BooleanSupplier sprintAllowed) {
+            FakeNavigation navigation = new FakeNavigation(nextStatus);
+            navigation.goal = goal;
+            navigation.reached = reached;
+            navigation.sprintAllowed = sprintAllowed;
+            created.add(navigation);
+            this.contextProvider = contextProvider;
+            this.sprintAllowed = sprintAllowed;
+            return navigation;
+        }
+
+        FakeNavigation last() {
+            return created.get(created.size() - 1);
+        }
+    }
+
+    static final class FakeNavigation implements OwnerFollowChain.Navigation {
+        PlayerNav.Status status;
+        int ticks;
+        int stops;
+        Runnable onTick = () -> {};
+        Supplier<GoalCompiler.Compiled> goal;
+        BooleanSupplier reached;
+        BooleanSupplier sprintAllowed;
+
+        FakeNavigation(PlayerNav.Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public PlayerNav.Status tick() {
+            ticks++;
+            onTick.run();
+            return status;
+        }
+
+        @Override
+        public void stop() {
+            stops++;
+        }
+    }
+
+    static final class FakeHalt implements OwnerFollowChain.HaltAction {
+        int calls;
+
+        @Override
+        public void halt(NumenPlayer companion) {
+            calls++;
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowControlIntegrationTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowControlIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class OwnerFollowControlIntegrationTest {
+
+    @Test
+    void controlsOnlyReleaseImmediatelyWhileSchedulerCreatesFreshNavigation() {
+        UUID uuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(OwnerFollowChainTestHarness.snapshot(
+                        FollowState.defaults(),
+                        true, true, true, true, true, 8.0, 10L));
+        Stage7BExecutionTestSupport.SchedulerDriver scheduler =
+                new Stage7BExecutionTestSupport.SchedulerDriver();
+        Stage7BExecutionTestSupport.BoundChainControl control =
+                new Stage7BExecutionTestSupport.BoundChainControl(
+                        uuid, harness.chain);
+
+        FollowControlResult on = apply(store, uuid, FollowAction.ON, 10L);
+        assertEquals("ENABLED", on.code());
+        assertEquals(0, harness.factory.created.size());
+        Stage7BExecutionTestSupport.syncIntent(
+                harness, store, uuid, 8.0, 10L);
+        assertSame(harness.chain, scheduler.step(List.of(harness.chain)));
+        OwnerFollowChainTestHarness.FakeNavigation first =
+                harness.factory.last();
+        store.bindRuntime(uuid, control);
+
+        FollowRuntimeSnapshot beforeStatus = harness.chain.snapshot(10L);
+        store.setDirty(false);
+        FollowControlResult status =
+                apply(store, uuid, FollowAction.STATUS, 10L);
+        assertEquals("STATUS", status.code());
+        assertFalse(status.changed());
+        assertFalse(store.isDirty());
+        assertSame(harness.chain, scheduler.running());
+        assertSame(first, harness.factory.last());
+        assertEquals(1, first.ticks);
+        assertEquals(beforeStatus, harness.chain.snapshot(10L));
+
+        FollowControlResult pause =
+                apply(store, uuid, FollowAction.PAUSE, 11L);
+        assertEquals("PAUSED", pause.code());
+        assertEquals(1, first.stops);
+        assertFalse(harness.chain.hasNavigation());
+        assertSame(control, store.runtimeControl(uuid).orElseThrow());
+        Stage7BExecutionTestSupport.syncIntent(
+                harness, store, uuid, 8.0, 11L);
+        assertEquals(null, scheduler.step(List.of(harness.chain)));
+        assertEquals(1, harness.factory.created.size());
+
+        FollowControlResult resume =
+                apply(store, uuid, FollowAction.RESUME, 12L);
+        assertEquals("RESUMED", resume.code());
+        assertEquals(1, harness.factory.created.size());
+        Stage7BExecutionTestSupport.syncIntent(
+                harness, store, uuid, 8.0, 12L);
+        assertSame(harness.chain, scheduler.step(List.of(harness.chain)));
+        OwnerFollowChainTestHarness.FakeNavigation second =
+                harness.factory.last();
+        assertNotSame(first, second);
+
+        FollowControlResult off =
+                apply(store, uuid, FollowAction.OFF, 13L);
+        assertEquals("DISABLED", off.code());
+        assertEquals(1, second.stops);
+        Stage7BExecutionTestSupport.syncIntent(
+                harness, store, uuid, 8.0, 13L);
+        assertEquals(null, scheduler.step(List.of(harness.chain)));
+        assertSame(control, store.runtimeControl(uuid).orElseThrow());
+
+        FollowControlResult repeatedOff =
+                apply(store, uuid, FollowAction.OFF, 14L);
+        assertEquals("ALREADY_DISABLED", repeatedOff.code());
+        assertEquals(1, second.stops);
+
+        apply(store, uuid, FollowAction.ON, 15L);
+        assertEquals(2, harness.factory.created.size());
+        Stage7BExecutionTestSupport.syncIntent(
+                harness, store, uuid, 8.0, 15L);
+        assertSame(harness.chain, scheduler.step(List.of(harness.chain)));
+        OwnerFollowChainTestHarness.FakeNavigation third =
+                harness.factory.last();
+        assertNotSame(second, third);
+        assertEquals(3, harness.factory.created.size());
+        assertTrue(harness.chain.snapshot(15L).navigationActive());
+        assertEquals(List.of(
+                FollowReleaseReason.MANUAL_PAUSE,
+                FollowReleaseReason.FOLLOW_DISABLED,
+                FollowReleaseReason.FOLLOW_DISABLED), control.reasons());
+    }
+
+    private static FollowControlResult apply(
+            FollowStateStore store,
+            UUID uuid,
+            FollowAction action,
+            long gameTime) {
+        return FollowService.apply(
+                store,
+                Stage7BExecutionTestSupport.subject(uuid, 8.0, gameTime),
+                action,
+                FollowConfig.defaults());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowLifecycleSequenceTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowLifecycleSequenceTest.java
@@ -1,0 +1,371 @@
+package com.dwinovo.numen.core.follow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class OwnerFollowLifecycleSequenceTest {
+
+    @Test
+    void delayedOldRemoveCannotDeleteRespawnedRuntimeWithSameUuid() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object oldBody = new Object();
+        Object respawnedBody = new Object();
+        TrackingControl deadRuntime = bind(store, companionUuid, oldBody);
+
+        store.removeRuntime(
+                companionUuid, oldBody, FollowReleaseReason.COMPANION_DEATH);
+        TrackingControl respawnedRuntime =
+                bind(store, companionUuid, respawnedBody);
+        store.removeRuntime(
+                companionUuid, oldBody, FollowReleaseReason.COMPANION_REMOVED);
+
+        assertCurrent(store, companionUuid, respawnedRuntime);
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_DEATH),
+                deadRuntime.reasons);
+        assertEquals(List.of(), respawnedRuntime.reasons);
+    }
+
+    @Test
+    void currentDeathRemovesAndReleasesCurrentRuntime() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object body = new Object();
+        TrackingControl runtime = bind(store, companionUuid, body);
+
+        store.removeRuntime(
+                companionUuid, body, FollowReleaseReason.COMPANION_DEATH);
+
+        assertTrue(store.runtimeControl(companionUuid).isEmpty());
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_DEATH),
+                runtime.reasons);
+    }
+
+    @Test
+    void currentRemoveRemovesAndReleasesCurrentRuntime() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object body = new Object();
+        TrackingControl runtime = bind(store, companionUuid, body);
+
+        store.removeRuntime(
+                companionUuid, body, FollowReleaseReason.COMPANION_REMOVED);
+
+        assertTrue(store.runtimeControl(companionUuid).isEmpty());
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_REMOVED),
+                runtime.reasons);
+    }
+
+    @Test
+    void deathThenDelayedRemoveForSameOldBodyIsSafeNoOp() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object body = new Object();
+        TrackingControl runtime = bind(store, companionUuid, body);
+
+        store.removeRuntime(
+                companionUuid, body, FollowReleaseReason.COMPANION_DEATH);
+        store.removeRuntime(
+                companionUuid, body, FollowReleaseReason.COMPANION_REMOVED);
+
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_DEATH),
+                runtime.reasons);
+        assertTrue(store.runtimeControl(companionUuid).isEmpty());
+    }
+
+    @Test
+    void staleDeathAfterRespawnDoesNotReleaseNewRuntime() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object oldBody = new Object();
+        Object respawnedBody = new Object();
+        TrackingControl oldRuntime = bind(store, companionUuid, oldBody);
+        store.removeRuntime(
+                companionUuid, oldBody, FollowReleaseReason.COMPANION_DEATH);
+        TrackingControl respawnedRuntime =
+                bind(store, companionUuid, respawnedBody);
+
+        store.removeRuntime(
+                companionUuid, oldBody, FollowReleaseReason.COMPANION_DEATH);
+
+        assertCurrent(store, companionUuid, respawnedRuntime);
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_DEATH),
+                oldRuntime.reasons);
+        assertEquals(List.of(), respawnedRuntime.reasons);
+    }
+
+    @Test
+    void repeatedStaleCallbacksNeverTouchRespawnedRuntime() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object oldBody = new Object();
+        Object respawnedBody = new Object();
+        TrackingControl oldRuntime = bind(store, companionUuid, oldBody);
+        store.removeRuntime(
+                companionUuid, oldBody, FollowReleaseReason.COMPANION_DEATH);
+        TrackingControl respawnedRuntime =
+                bind(store, companionUuid, respawnedBody);
+
+        for (int attempt = 0; attempt < 3; attempt++) {
+            store.removeRuntime(
+                    companionUuid,
+                    oldBody,
+                    FollowReleaseReason.COMPANION_REMOVED);
+            store.removeRuntime(
+                    companionUuid,
+                    oldRuntime,
+                    FollowReleaseReason.COMPANION_DEATH);
+        }
+
+        assertCurrent(store, companionUuid, respawnedRuntime);
+        assertEquals(List.of(), respawnedRuntime.reasons);
+    }
+
+    @Test
+    void runtimeReplacementStaysVisibleDuringAndAfterOldCallback() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object body = new Object();
+        TrackingControl oldRuntime = new TrackingControl(companionUuid);
+        TrackingControl replacement = new TrackingControl(companionUuid);
+        store.bindRuntime(companionUuid, body, oldRuntime);
+        oldRuntime.onRelease = () -> {
+            assertCurrent(store, companionUuid, replacement);
+            store.removeRuntime(
+                    companionUuid,
+                    oldRuntime,
+                    FollowReleaseReason.COMPANION_REMOVED);
+            assertCurrent(store, companionUuid, replacement);
+        };
+
+        store.bindRuntime(companionUuid, body, replacement);
+        store.removeRuntime(
+                companionUuid,
+                oldRuntime,
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertCurrent(store, companionUuid, replacement);
+        assertEquals(
+                List.of(FollowReleaseReason.RUNTIME_REPLACED),
+                oldRuntime.reasons);
+        assertEquals(List.of(), replacement.reasons);
+    }
+
+    @Test
+    void rebindingSameRuntimeToNewBodyRefreshesLifecycleIdentity() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object oldBody = new Object();
+        Object newBody = new Object();
+        TrackingControl runtime = new TrackingControl(companionUuid);
+        store.bindRuntime(companionUuid, oldBody, runtime);
+
+        store.bindRuntime(companionUuid, newBody, runtime);
+        store.removeRuntime(
+                companionUuid,
+                oldBody,
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertCurrent(store, companionUuid, runtime);
+        assertEquals(List.of(), runtime.reasons);
+
+        store.removeRuntime(
+                companionUuid,
+                newBody,
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertTrue(store.runtimeControl(companionUuid).isEmpty());
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_REMOVED),
+                runtime.reasons);
+    }
+
+    @Test
+    void equalButDistinctBodyIdentityIsStale() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        EqualIdentity currentBody = new EqualIdentity("body");
+        EqualIdentity staleEqualBody = new EqualIdentity("body");
+        TrackingControl runtime = bind(store, companionUuid, currentBody);
+
+        store.removeRuntime(
+                companionUuid,
+                staleEqualBody,
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertCurrent(store, companionUuid, runtime);
+        assertEquals(List.of(), runtime.reasons);
+    }
+
+    @Test
+    void differentCompanionUuidsRemainGenerationIsolated() {
+        UUID firstUuid = UUID.randomUUID();
+        UUID secondUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object firstBody = new Object();
+        Object secondBody = new Object();
+        TrackingControl first = bind(store, firstUuid, firstBody);
+        TrackingControl second = bind(store, secondUuid, secondBody);
+
+        store.removeRuntime(
+                firstUuid, firstBody, FollowReleaseReason.COMPANION_REMOVED);
+
+        assertTrue(store.runtimeControl(firstUuid).isEmpty());
+        assertCurrent(store, secondUuid, second);
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_REMOVED),
+                first.reasons);
+        assertEquals(List.of(), second.reasons);
+    }
+
+    @Test
+    void staleCallbackDoesNotModifyPersistentFollowState() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowState intent = new FollowState(
+                true,
+                true,
+                FollowState.CURRENT_SCHEMA_VERSION,
+                2.5,
+                6.5);
+        FollowStateStore store = new FollowStateStore();
+        store.put(companionUuid, intent);
+        store.setDirty(false);
+        Object currentBody = new Object();
+        TrackingControl runtime =
+                bind(store, companionUuid, currentBody);
+
+        store.removeRuntime(
+                companionUuid,
+                new Object(),
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertCurrent(store, companionUuid, runtime);
+        assertEquals(intent, store.getOrDefault(companionUuid));
+        assertFalse(store.isDirty());
+    }
+
+    @Test
+    void serverStoppingStillReleasesEveryCurrentRuntime() {
+        FollowStateStore store = new FollowStateStore();
+        TrackingControl first =
+                bind(store, UUID.randomUUID(), new Object());
+        TrackingControl second =
+                bind(store, UUID.randomUUID(), new Object());
+
+        int failures = store.releaseAllRuntime(
+                FollowReleaseReason.SERVER_STOPPING);
+
+        assertEquals(0, failures);
+        assertEquals(0, store.runtimeControlCount());
+        assertEquals(
+                List.of(FollowReleaseReason.SERVER_STOPPING),
+                first.reasons);
+        assertEquals(
+                List.of(FollowReleaseReason.SERVER_STOPPING),
+                second.reasons);
+    }
+
+    @Test
+    void releaseFailureStillLeavesConditionallyRemovedRegistryEmpty() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object body = new Object();
+        TrackingControl faulty = bind(store, companionUuid, body);
+        faulty.throwOnRelease = true;
+
+        store.removeRuntime(
+                companionUuid, body, FollowReleaseReason.COMPANION_REMOVED);
+
+        assertTrue(store.runtimeControl(companionUuid).isEmpty());
+        assertEquals(
+                List.of(FollowReleaseReason.COMPANION_REMOVED),
+                faulty.reasons);
+    }
+
+    @Test
+    void staleIdentityNeverInvokesFaultyCurrentRuntime() {
+        UUID companionUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        Object currentBody = new Object();
+        TrackingControl faulty =
+                bind(store, companionUuid, currentBody);
+        faulty.throwOnRelease = true;
+
+        store.removeRuntime(
+                companionUuid,
+                new Object(),
+                FollowReleaseReason.COMPANION_REMOVED);
+
+        assertCurrent(store, companionUuid, faulty);
+        assertEquals(List.of(), faulty.reasons);
+    }
+
+    private static TrackingControl bind(
+            FollowStateStore store, UUID companionUuid, Object identity) {
+        TrackingControl control = new TrackingControl(companionUuid);
+        store.bindRuntime(companionUuid, identity, control);
+        return control;
+    }
+
+    private static void assertCurrent(
+            FollowStateStore store,
+            UUID companionUuid,
+            FollowRuntimeControl expected) {
+        assertSame(
+                expected,
+                store.runtimeControl(companionUuid).orElseThrow());
+    }
+
+    private record EqualIdentity(String value) {}
+
+    private static final class TrackingControl implements FollowRuntimeControl {
+        private final UUID companionUuid;
+        private final List<FollowReleaseReason> reasons = new ArrayList<>();
+        private Runnable onRelease = () -> {};
+        private boolean throwOnRelease;
+
+        private TrackingControl(UUID companionUuid) {
+            this.companionUuid = companionUuid;
+        }
+
+        @Override
+        public UUID companionUuid() {
+            return companionUuid;
+        }
+
+        @Override
+        public void release(FollowReleaseReason reason) {
+            reasons.add(reason);
+            onRelease.run();
+            if (throwOnRelease) {
+                throw new IllegalStateException("deliberate release failure");
+            }
+        }
+
+        @Override
+        public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+            return new FollowRuntimeSnapshot(
+                    FollowRuntimeState.FOLLOWING,
+                    FollowWaitingReason.NONE,
+                    true,
+                    false,
+                    false,
+                    false,
+                    FollowDecisions.NO_FAILED_COOLDOWN,
+                    0L);
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowMultiCompanionExecutionTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowMultiCompanionExecutionTest.java
@@ -1,0 +1,110 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+
+class OwnerFollowMultiCompanionExecutionTest {
+
+    @Test
+    void interruptFailurePauseDeathReplacementAndShutdownStayUuidIsolated() {
+        UUID firstUuid = UUID.randomUUID();
+        UUID secondUuid = UUID.randomUUID();
+        FollowStateStore store = new FollowStateStore();
+        store.put(firstUuid, OwnerFollowChainTestHarness.enabled());
+        store.put(secondUuid, OwnerFollowChainTestHarness.enabled());
+        FollowState firstIntent = store.getOrDefault(firstUuid);
+        FollowState secondIntent = store.getOrDefault(secondUuid);
+
+        OwnerFollowChainTestHarness first =
+                new OwnerFollowChainTestHarness(activeAt(24.0, 10L));
+        OwnerFollowChainTestHarness second =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        first.chain.tick(null);
+        second.chain.tick(null);
+        Stage7BExecutionTestSupport.BoundChainControl firstControl =
+                new Stage7BExecutionTestSupport.BoundChainControl(
+                        firstUuid, first.chain);
+        Stage7BExecutionTestSupport.BoundChainControl secondControl =
+                new Stage7BExecutionTestSupport.BoundChainControl(
+                        secondUuid, second.chain);
+        store.bindRuntime(firstUuid, firstControl);
+        store.bindRuntime(secondUuid, secondControl);
+        OwnerFollowChainTestHarness.FakeNavigation secondNavigation =
+                second.factory.last();
+
+        assertTrue(first.chain.snapshot(10L).sprintAllowed());
+        assertTrue(first.chain.snapshot(10L).catchingUp());
+        assertFalse(second.chain.snapshot(10L).sprintAllowed());
+        assertFalse(second.chain.snapshot(10L).catchingUp());
+
+        OwnerFollowChainTestHarness.FakeNavigation interrupted =
+                first.factory.last();
+        first.chain.onInterrupt(null);
+        assertEquals(1, interrupted.stops);
+        assertEquals(0, secondNavigation.stops);
+        first.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation failed =
+                first.factory.last();
+        assertNotSame(interrupted, failed);
+        assertSame(FollowContextProvider.INSTANCE, failed.contextProvider);
+        failed.status = PlayerNav.Status.FAILED;
+        first.access.snapshot = activeAt(24.0, 20L);
+        first.chain.tick(null);
+        assertEquals(120L, first.chain.snapshot(20L).failedUntilTick());
+        assertTrue(second.chain.snapshot(20L).navigationActive());
+        assertEquals(1, secondNavigation.ticks);
+
+        FollowService.apply(
+                store,
+                Stage7BExecutionTestSupport.subject(firstUuid, 24.0, 21L),
+                FollowAction.PAUSE,
+                FollowConfig.defaults());
+        assertTrue(store.getOrDefault(firstUuid).manualPaused());
+        assertEquals(secondIntent, store.getOrDefault(secondUuid));
+        assertSame(secondControl,
+                store.runtimeControl(secondUuid).orElseThrow());
+        assertEquals(0, secondNavigation.stops);
+
+        OwnerFollowChainTestHarness replacement =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 22L));
+        replacement.chain.tick(null);
+        Stage7BExecutionTestSupport.BoundChainControl replacementControl =
+                new Stage7BExecutionTestSupport.BoundChainControl(
+                        firstUuid, replacement.chain);
+        store.bindRuntime(firstUuid, replacementControl);
+        assertSame(replacementControl,
+                store.runtimeControl(firstUuid).orElseThrow());
+        assertEquals(1, replacement.factory.created.size());
+        assertSame(FollowContextProvider.INSTANCE,
+                replacement.factory.last().contextProvider);
+        assertEquals(0, secondNavigation.stops);
+
+        store.removeRuntime(
+                firstUuid, replacementControl,
+                FollowReleaseReason.COMPANION_DEATH);
+        assertFalse(store.runtimeControl(firstUuid).isPresent());
+        assertEquals(1, replacement.factory.last().stops);
+        assertSame(secondControl,
+                store.runtimeControl(secondUuid).orElseThrow());
+        assertEquals(0, secondNavigation.stops);
+
+        assertEquals(0,
+                store.releaseAllRuntime(FollowReleaseReason.SERVER_STOPPING));
+        assertEquals(0, store.runtimeControlCount());
+        assertEquals(1, secondNavigation.stops);
+        assertEquals(firstIntent.enabled(),
+                store.getOrDefault(firstUuid).enabled());
+        assertTrue(store.getOrDefault(firstUuid).manualPaused());
+        assertEquals(secondIntent, store.getOrDefault(secondUuid));
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowNavigationReleaseSequenceTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowNavigationReleaseSequenceTest.java
@@ -1,0 +1,213 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+import org.junit.jupiter.api.Test;
+
+import com.dwinovo.numen.core.pathing.exec.PlayerNav;
+import com.dwinovo.numen.core.pathing.exec.PlayerNavSprintGateTestProbe;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
+
+class OwnerFollowNavigationReleaseSequenceTest {
+
+    @Test
+    void unavailableOwnerMatrixReleasesActiveNavigationWithoutRetick() {
+        List<ReleaseCase> cases = List.of(
+                new ReleaseCase(
+                        OwnerFollowChainTestHarness.snapshot(
+                                OwnerFollowChainTestHarness.enabled(),
+                                true, true, false, false, false,
+                                Double.NaN, 11L),
+                        FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.OWNER_OFFLINE),
+                new ReleaseCase(
+                        OwnerFollowChainTestHarness.snapshot(
+                                OwnerFollowChainTestHarness.enabled(),
+                                true, false, false, false, false,
+                                Double.NaN, 11L),
+                        FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.OWNER_INVALID),
+                new ReleaseCase(
+                        OwnerFollowChainTestHarness.snapshot(
+                                OwnerFollowChainTestHarness.enabled(),
+                                true, true, true, true, false,
+                                Double.NaN, 11L),
+                        FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.OWNER_OTHER_DIMENSION),
+                new ReleaseCase(
+                        OwnerFollowChainTestHarness.snapshot(
+                                OwnerFollowChainTestHarness.enabled(),
+                                true, true, true, true, true,
+                                FollowConfig.DEFAULT_LOST_DISTANCE, 11L),
+                        FollowRuntimeState.WAITING_FOR_OWNER,
+                        FollowWaitingReason.OWNER_TOO_FAR),
+                new ReleaseCase(
+                        activeAt(FollowConfig.DEFAULT_STOP_DISTANCE, 11L),
+                        FollowRuntimeState.IDLE_NEAR_OWNER,
+                        FollowWaitingReason.NONE));
+
+        for (ReleaseCase releaseCase : cases) {
+            OwnerFollowChainTestHarness harness =
+                    new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+            Stage7BExecutionTestSupport.SchedulerDriver scheduler =
+                    new Stage7BExecutionTestSupport.SchedulerDriver();
+            scheduler.step(List.of(harness.chain));
+            OwnerFollowChainTestHarness.FakeNavigation old =
+                    harness.factory.last();
+
+            harness.access.snapshot = releaseCase.snapshot();
+            assertEquals(null, scheduler.step(List.of(harness.chain)));
+            assertEquals(null, scheduler.step(List.of(harness.chain)));
+
+            FollowRuntimeSnapshot runtime = harness.chain.snapshot(11L);
+            assertEquals(releaseCase.runtimeState(), runtime.runtimeState());
+            assertEquals(releaseCase.waitingReason(), runtime.waitingReason());
+            assertFalse(runtime.navigationActive());
+            assertEquals(1, old.ticks);
+            assertEquals(1, old.stops);
+            assertEquals(1, harness.factory.created.size());
+        }
+    }
+
+    @Test
+    void runningFailureCooldownAndRetryUseFreshSafeNavigation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        Stage7BExecutionTestSupport.SchedulerDriver scheduler =
+                new Stage7BExecutionTestSupport.SchedulerDriver();
+        scheduler.step(List.of(harness.chain));
+        OwnerFollowChainTestHarness.FakeNavigation first =
+                harness.factory.last();
+        assertSafe(first);
+
+        harness.access.snapshot = activeAt(16.0, 11L);
+        scheduler.step(List.of(harness.chain));
+        harness.access.snapshot = activeAt(24.0, 12L);
+        scheduler.step(List.of(harness.chain));
+        harness.access.snapshot = activeAt(8.0, 13L);
+        scheduler.step(List.of(harness.chain));
+        assertSame(first, harness.factory.last());
+        assertEquals(4, first.ticks);
+        assertFalse(harness.chain.snapshot(13L).sprintAllowed());
+        assertFalse(harness.chain.snapshot(13L).catchingUp());
+
+        first.status = PlayerNav.Status.FAILED;
+        harness.access.snapshot = activeAt(8.0, 20L);
+        scheduler.step(List.of(harness.chain));
+        assertEquals(1, first.stops);
+        assertEquals(120L, harness.chain.snapshot(20L).failedUntilTick());
+        assertFalse(harness.chain.snapshot(20L).navigationActive());
+
+        harness.access.snapshot = activeAt(8.0, 119L);
+        assertEquals(null, scheduler.step(List.of(harness.chain)));
+        assertEquals(1, harness.factory.created.size());
+
+        harness.factory.nextStatus = PlayerNav.Status.RUNNING;
+        harness.access.snapshot = activeAt(8.0, 120L);
+        assertSame(harness.chain, scheduler.step(List.of(harness.chain)));
+        OwnerFollowChainTestHarness.FakeNavigation retry =
+                harness.factory.last();
+        assertNotSame(first, retry);
+        assertSafe(retry);
+        assertEquals(2, harness.factory.created.size());
+        assertEquals(1, retry.ticks);
+        assertEquals(5, first.ticks);
+    }
+
+    @Test
+    void ownerChainGateDrivesPlayerNavGuardWithoutRebuildingNavigation() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        BooleanSupplier gate = navigation.sprintAllowed;
+
+        assertFalse(PlayerNavSprintGateTestProbe.observeGuard(gate));
+        harness.access.snapshot = activeAt(16.0, 11L);
+        harness.chain.tick(null);
+        assertTrue(PlayerNavSprintGateTestProbe.observeGuard(gate));
+        harness.access.snapshot = activeAt(8.0, 12L);
+        harness.chain.tick(null);
+        assertFalse(PlayerNavSprintGateTestProbe.observeGuard(gate));
+
+        assertSame(navigation, harness.factory.last());
+        assertEquals(1, harness.factory.created.size());
+        assertEquals(3, navigation.ticks);
+    }
+
+    @Test
+    void stopAndHaltFailuresStillClearNavigationAndDynamicFlags() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(24.0, 10L));
+        harness.chain.tick(null);
+        OwnerFollowChainTestHarness.FakeNavigation navigation =
+                harness.factory.last();
+        navigation.throwOnStop = true;
+        harness.halt.throwOnHalt = true;
+
+        IllegalStateException failure = assertThrows(
+                IllegalStateException.class,
+                () -> harness.chain.onInterrupt(null));
+
+        assertEquals("deliberate navigation stop failure", failure.getMessage());
+        assertEquals(1, failure.getSuppressed().length);
+        assertEquals("deliberate input halt failure",
+                failure.getSuppressed()[0].getMessage());
+        FollowRuntimeSnapshot runtime = harness.chain.snapshot(10L);
+        assertFalse(runtime.navigationActive());
+        assertFalse(runtime.sprintAllowed());
+        assertFalse(runtime.catchingUp());
+        assertTrue(runtime.following());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                runtime.failedUntilTick());
+        assertEquals(1, navigation.ticks);
+        assertEquals(1, navigation.stops);
+        assertEquals(1, harness.halt.calls);
+    }
+
+    @Test
+    void internalStateChangePreservesExistingLatchAndDeadline() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.factory.nextStatus = PlayerNav.Status.FAILED;
+        harness.chain.tick(null);
+        FollowRuntimeSnapshot failed = harness.chain.snapshot(10L);
+
+        harness.chain.release(FollowReleaseReason.INTERNAL_STATE_CHANGE);
+
+        FollowRuntimeSnapshot released = harness.chain.snapshot(10L);
+        assertEquals(FollowRuntimeState.FAILED_COOLDOWN,
+                released.runtimeState());
+        assertTrue(released.following());
+        assertEquals(failed.failedUntilTick(), released.failedUntilTick());
+        assertFalse(released.navigationActive());
+    }
+
+    private static void assertSafe(
+            OwnerFollowChainTestHarness.FakeNavigation navigation) {
+        assertSame(FollowContextProvider.INSTANCE, navigation.contextProvider);
+        assertNotSame(PlayerNav.ContextProvider.DEFAULT,
+                navigation.contextProvider);
+        NavigationCapabilities capabilities =
+                FollowContextProvider.capabilities();
+        assertSame(NavigationCapabilities.SAFE_FOLLOW, capabilities);
+        assertFalse(capabilities.permitsBreak(true));
+        assertFalse(capabilities.permitsPlace(true));
+        assertFalse(capabilities.permitsWaterBucketLanding(true));
+    }
+
+    private record ReleaseCase(
+            OwnerFollowChain.Snapshot snapshot,
+            FollowRuntimeState runtimeState,
+            FollowWaitingReason waitingReason) {}
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowSchedulerCoordinationTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowSchedulerCoordinationTest.java
@@ -1,0 +1,138 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.dwinovo.numen.task.ChainScheduler;
+import com.dwinovo.numen.task.TaskChain;
+
+class OwnerFollowSchedulerCoordinationTest {
+
+    @Test
+    void explicitPriorityZeroPreemptsFollowMinusTwo() {
+        assertPreempts(0.0F);
+    }
+
+    @Test
+    void speakingLookPriorityMinusOnePreemptsFollowMinusTwo() {
+        assertPreempts(-1.0F);
+    }
+
+    @Test
+    void survivalPriorityPreemptsFollowMinusTwo() {
+        assertPreempts(10.0F);
+    }
+
+    @Test
+    void preemptionStopsHaltsWithoutCooldownOrIntentMutation() {
+        OwnerFollowChainTestHarness harness = runningHarness();
+        OwnerFollowChainTestHarness.FakeNavigation navigation = harness.factory.last();
+        FollowState intent = harness.access.snapshot.state();
+
+        harness.chain.onInterrupt(null);
+
+        assertEquals(1, navigation.stops);
+        assertEquals(1, harness.halt.calls);
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                harness.chain.snapshot(10L).failedUntilTick());
+        assertEquals(intent, harness.access.snapshot.state());
+    }
+
+    @Test
+    void followResumesWithNewNavigationAfterHigherPrioritySleeps() {
+        OwnerFollowChainTestHarness harness = runningHarness();
+        OwnerFollowChainTestHarness.FakeNavigation oldNavigation = harness.factory.last();
+        TaskChain higher = chainAt(0.0F);
+        TaskChain winner = ChainScheduler.select(List.of(harness.chain, higher), null);
+        assertSame(higher, winner);
+        harness.chain.onInterrupt(null);
+
+        TaskChain resumed = ChainScheduler.select(List.of(harness.chain), null);
+        resumed.tick(null);
+
+        assertSame(harness.chain, resumed);
+        assertEquals(2, harness.factory.created.size());
+        assertNotSame(oldNavigation, harness.factory.last());
+        assertTrue(harness.chain.snapshot(10L).navigationActive());
+    }
+
+    @Test
+    void noEligibleWinnerInterruptsPreviouslyRunningFollow() {
+        OwnerFollowChainTestHarness harness = runningHarness();
+        harness.access.snapshot = new OwnerFollowChain.Snapshot(
+                FollowState.defaults(), true, true, true, true, true, 8.0, 11L);
+
+        TaskChain winner = ChainScheduler.select(List.of(harness.chain), null);
+        if (winner == null) {
+            harness.chain.onInterrupt(null);
+        }
+
+        assertEquals(null, winner);
+        assertFalse(harness.chain.snapshot(11L).navigationActive());
+        assertEquals(1, harness.factory.last().stops);
+    }
+
+    @Test
+    void independentChainsNeverShareNavigationOrCooldown() {
+        OwnerFollowChainTestHarness first = runningHarness();
+        OwnerFollowChainTestHarness second = runningHarness();
+        first.chain.onInterrupt(null);
+
+        assertFalse(first.chain.snapshot(10L).navigationActive());
+        assertTrue(second.chain.snapshot(10L).navigationActive());
+        assertNotSame(first.factory.last(), second.factory.last());
+        assertEquals(FollowDecisions.NO_FAILED_COOLDOWN,
+                second.chain.snapshot(10L).failedUntilTick());
+    }
+
+    private static void assertPreempts(float priority) {
+        OwnerFollowChainTestHarness harness = runningHarness();
+        TaskChain higher = chainAt(priority);
+
+        TaskChain winner =
+                ChainScheduler.select(List.of(harness.chain, higher), null);
+        if (winner != harness.chain) {
+            harness.chain.onInterrupt(null);
+        }
+
+        assertSame(higher, winner);
+        assertEquals(1, harness.factory.last().stops);
+        assertFalse(harness.chain.snapshot(10L).navigationActive());
+    }
+
+    private static OwnerFollowChainTestHarness runningHarness() {
+        OwnerFollowChainTestHarness harness =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        harness.chain.tick(null);
+        return harness;
+    }
+
+    private static TaskChain chainAt(float priority) {
+        return new TaskChain() {
+            @Override
+            public float getPriority(NumenPlayer companion) {
+                return priority;
+            }
+
+            @Override
+            public void tick(NumenPlayer companion) {}
+
+            @Override
+            public void onInterrupt(NumenPlayer companion) {}
+
+            @Override
+            public String name() {
+                return "test_priority_" + priority;
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowSchedulerSequenceTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/OwnerFollowSchedulerSequenceTest.java
@@ -1,0 +1,85 @@
+package com.dwinovo.numen.core.follow;
+
+import static com.dwinovo.numen.core.follow.OwnerFollowChainTestHarness.activeAt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.dwinovo.numen.task.TaskChain;
+
+class OwnerFollowSchedulerSequenceTest {
+
+    @Test
+    void completeWinnerSequenceInterruptsBeforeTickAndResumesFreshNavigation() {
+        List<String> events = new ArrayList<>();
+        OwnerFollowChainTestHarness follow =
+                new OwnerFollowChainTestHarness(activeAt(8.0, 10L));
+        Stage7BExecutionTestSupport.MutableChain speaking =
+                new Stage7BExecutionTestSupport.MutableChain("speaking", events);
+        Stage7BExecutionTestSupport.MutableChain llm =
+                new Stage7BExecutionTestSupport.MutableChain("llm", events);
+        Stage7BExecutionTestSupport.MutableChain survival =
+                new Stage7BExecutionTestSupport.MutableChain("survival", events);
+        List<TaskChain> chains =
+                List.of(follow.chain, speaking, llm, survival);
+        Stage7BExecutionTestSupport.SchedulerDriver scheduler =
+                new Stage7BExecutionTestSupport.SchedulerDriver();
+
+        assertSame(follow.chain, scheduler.step(chains));
+        OwnerFollowChainTestHarness.FakeNavigation first =
+                follow.factory.last();
+        first.onStop = () -> events.add("follow.stop");
+
+        speaking.priority(-1.0F);
+        assertSame(speaking, scheduler.step(chains));
+
+        llm.priority(0.0F);
+        assertSame(llm, scheduler.step(chains));
+        assertSame(llm, scheduler.step(chains));
+
+        survival.priority(10.0F);
+        assertSame(survival, scheduler.step(chains));
+
+        speaking.priority(Float.NEGATIVE_INFINITY);
+        llm.priority(Float.NEGATIVE_INFINITY);
+        survival.priority(Float.NEGATIVE_INFINITY);
+        follow.access.snapshot = OwnerFollowChainTestHarness.snapshot(
+                FollowState.defaults(),
+                true, true, true, true, true, 8.0, 15L);
+        assertNull(scheduler.step(chains));
+        assertNull(scheduler.running());
+
+        follow.access.snapshot = activeAt(8.0, 16L);
+        assertSame(follow.chain, scheduler.step(chains));
+        OwnerFollowChainTestHarness.FakeNavigation resumed =
+                follow.factory.last();
+
+        assertEquals(List.of(
+                "follow.stop",
+                "speaking.tick",
+                "speaking.interrupt",
+                "llm.tick",
+                "llm.tick",
+                "llm.interrupt",
+                "survival.tick",
+                "survival.interrupt"), events);
+        assertEquals(1, speaking.ticks());
+        assertEquals(1, speaking.interrupts());
+        assertEquals(2, llm.ticks());
+        assertEquals(1, llm.interrupts());
+        assertEquals(1, survival.ticks());
+        assertEquals(1, survival.interrupts());
+        assertEquals(6, scheduler.winnerTicks());
+        assertEquals(1, first.ticks);
+        assertEquals(1, first.stops);
+        assertEquals(1, resumed.ticks);
+        assertNotSame(first, resumed);
+        assertEquals(2, follow.factory.created.size());
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/follow/Stage7BExecutionTestSupport.java
+++ b/common/src/test/java/com/dwinovo/numen/core/follow/Stage7BExecutionTestSupport.java
@@ -1,0 +1,141 @@
+package com.dwinovo.numen.core.follow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+import com.dwinovo.numen.entity.NumenPlayer;
+import com.dwinovo.numen.task.ChainScheduler;
+import com.dwinovo.numen.task.TaskChain;
+
+final class Stage7BExecutionTestSupport {
+
+    private Stage7BExecutionTestSupport() {}
+
+    static FollowService.Subject subject(UUID uuid, double distance, long gameTime) {
+        return new FollowService.Subject(
+                uuid, "Numen", true, true, true, true, true,
+                OptionalDouble.of(distance), gameTime);
+    }
+
+    static void syncIntent(
+            OwnerFollowChainTestHarness harness,
+            FollowStateStore store,
+            UUID uuid,
+            double distance,
+            long gameTime) {
+        harness.access.snapshot = OwnerFollowChainTestHarness.snapshot(
+                store.getOrDefault(uuid),
+                true, true, true, true, true, distance, gameTime);
+    }
+
+    static final class SchedulerDriver {
+        private TaskChain running;
+        private int winnerTicks;
+
+        TaskChain step(List<TaskChain> chains) {
+            TaskChain best = ChainScheduler.select(chains, null);
+            if (best == null) {
+                if (running != null) {
+                    running.onInterrupt(null);
+                    running = null;
+                }
+                return null;
+            }
+            if (running != null && running != best) {
+                running.onInterrupt(null);
+            }
+            running = best;
+            best.tick(null);
+            winnerTicks++;
+            return best;
+        }
+
+        TaskChain running() {
+            return running;
+        }
+
+        int winnerTicks() {
+            return winnerTicks;
+        }
+    }
+
+    static final class MutableChain implements TaskChain {
+        private final String name;
+        private final List<String> events;
+        private float priority = Float.NEGATIVE_INFINITY;
+        private int ticks;
+        private int interrupts;
+
+        MutableChain(String name, List<String> events) {
+            this.name = name;
+            this.events = events;
+        }
+
+        void priority(float priority) {
+            this.priority = priority;
+        }
+
+        int ticks() {
+            return ticks;
+        }
+
+        int interrupts() {
+            return interrupts;
+        }
+
+        @Override
+        public float getPriority(NumenPlayer companion) {
+            return priority;
+        }
+
+        @Override
+        public void tick(NumenPlayer companion) {
+            ticks++;
+            events.add(name + ".tick");
+        }
+
+        @Override
+        public void onInterrupt(NumenPlayer companion) {
+            interrupts++;
+            events.add(name + ".interrupt");
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+
+    static final class BoundChainControl implements FollowRuntimeControl {
+        private final UUID uuid;
+        private final OwnerFollowChain chain;
+        private final List<FollowReleaseReason> reasons = new ArrayList<>();
+
+        BoundChainControl(UUID uuid, OwnerFollowChain chain) {
+            this.uuid = uuid;
+            this.chain = chain;
+        }
+
+        @Override
+        public UUID companionUuid() {
+            return uuid;
+        }
+
+        @Override
+        public void release(FollowReleaseReason reason) {
+            reasons.add(reason);
+            chain.release(reason);
+        }
+
+        @Override
+        public FollowRuntimeSnapshot snapshot(long currentGameTime) {
+            return chain.snapshot(currentGameTime);
+        }
+
+        List<FollowReleaseReason> reasons() {
+            return List.copyOf(reasons);
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/pathing/exec/PlayerNavDynamicSprintGateTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/pathing/exec/PlayerNavDynamicSprintGateTest.java
@@ -1,0 +1,183 @@
+package com.dwinovo.numen.core.pathing.exec;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import com.dwinovo.numen.core.pathing.goal.GoalCompiler;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
+import com.dwinovo.numen.core.pathing.settings.NavSettings;
+import com.dwinovo.numen.entity.NumenPlayer;
+
+import net.minecraft.core.BlockPos;
+
+import org.junit.jupiter.api.Test;
+
+class PlayerNavDynamicSprintGateTest {
+
+    @Test
+    void legacySpeedGateKeepsItsExactMeaning() {
+        assertFalse(PlayerNav.legacySprintGate(0.99).getAsBoolean());
+        assertTrue(PlayerNav.legacySprintGate(1.0).getAsBoolean());
+        assertTrue(PlayerNav.legacySprintGate(2.0).getAsBoolean());
+    }
+
+    @Test
+    void dynamicGateIsAdditionalToLegacySpeedGate() {
+        assertFalse(PlayerNav.combinedSprintGate(0.99, () -> true).getAsBoolean());
+        assertFalse(PlayerNav.combinedSprintGate(1.0, () -> false).getAsBoolean());
+        assertTrue(PlayerNav.combinedSprintGate(1.0, () -> true).getAsBoolean());
+    }
+
+    @Test
+    void sameSupplierCanChangeWithoutCreatingANewGate() {
+        AtomicBoolean allowed = new AtomicBoolean(false);
+        BooleanSupplier gate = PlayerNav.combinedSprintGate(1.0, allowed::get);
+
+        assertFalse(gate.getAsBoolean());
+        allowed.set(true);
+        assertTrue(gate.getAsBoolean());
+        allowed.set(false);
+        assertFalse(gate.getAsBoolean());
+    }
+
+    @Test
+    void falseGateDisablesSprintInsideGuardAndRestoresAfterward() {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        try {
+            settings.allowSprint = true;
+            PlayerNav.withSprintGate(() -> false,
+                    () -> assertFalse(settings.allowSprint));
+            assertTrue(settings.allowSprint);
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+
+    @Test
+    void trueGateOnlyAllowsAndDoesNotForceSprint() {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        try {
+            settings.allowSprint = false;
+            PlayerNav.withSprintGate(() -> true,
+                    () -> assertFalse(settings.allowSprint));
+            assertFalse(settings.allowSprint);
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+
+    @Test
+    void guardRestoresGlobalSettingWhenBodyThrows() {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        try {
+            settings.allowSprint = true;
+            assertThrows(IllegalStateException.class,
+                    () -> PlayerNav.withSprintGate(() -> false, () -> {
+                        assertFalse(settings.allowSprint);
+                        throw new IllegalStateException("expected");
+                    }));
+            assertTrue(settings.allowSprint);
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+
+    @Test
+    void twoSequentialNavigationGatesRemainIsolated() {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        try {
+            settings.allowSprint = true;
+            PlayerNav.withSprintGate(() -> false,
+                    () -> assertFalse(settings.allowSprint));
+            PlayerNav.withSprintGate(() -> true,
+                    () -> assertTrue(settings.allowSprint));
+            assertTrue(settings.allowSprint);
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+
+    @Test
+    void supplierIsResampledOnEveryGuardedDrive() {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        AtomicBoolean allowed = new AtomicBoolean(false);
+        try {
+            settings.allowSprint = true;
+            PlayerNav.withSprintGate(allowed::get,
+                    () -> assertFalse(settings.allowSprint));
+            allowed.set(true);
+            PlayerNav.withSprintGate(allowed::get,
+                    () -> assertTrue(settings.allowSprint));
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+
+    @Test
+    void legacyAndNewEntryPointSignaturesRemainCompileTimeCompatible() {
+        FixedGoalConstructor fixedGoalConstructor = PlayerNav::new;
+        MovingGoalConstructor movingGoalConstructor = PlayerNav::new;
+        LegacyRevalidatingFactory legacyFactory = PlayerNav::toRevalidating;
+        DynamicRevalidatingFactory dynamicFactory = PlayerNav::toRevalidating;
+
+        assertNotNull(fixedGoalConstructor);
+        assertNotNull(movingGoalConstructor);
+        assertNotNull(legacyFactory);
+        assertNotNull(dynamicFactory);
+    }
+
+    @Test
+    void sprintGateDoesNotRelaxSafeFollowCapabilities() {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        try {
+            settings.allowSprint = true;
+            PlayerNav.withSprintGate(() -> true, () -> {
+                assertFalse(NavigationCapabilities.SAFE_FOLLOW.permitsBreak(true));
+                assertFalse(NavigationCapabilities.SAFE_FOLLOW.permitsPlace(true));
+                assertFalse(NavigationCapabilities.SAFE_FOLLOW
+                        .permitsWaterBucketLanding(true));
+            });
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+
+    @FunctionalInterface
+    private interface FixedGoalConstructor {
+        PlayerNav create(NumenPlayer player, BlockPos goal, double speed,
+                         BooleanSupplier reached);
+    }
+
+    @FunctionalInterface
+    private interface MovingGoalConstructor {
+        PlayerNav create(NumenPlayer player, Supplier<BlockPos> goal, double speed,
+                         BooleanSupplier reached);
+    }
+
+    @FunctionalInterface
+    private interface LegacyRevalidatingFactory {
+        PlayerNav create(NumenPlayer player, Supplier<GoalCompiler.Compiled> compiled,
+                         double speed, BooleanSupplier reached,
+                         PlayerNav.ContextProvider contextProvider);
+    }
+
+    @FunctionalInterface
+    private interface DynamicRevalidatingFactory {
+        PlayerNav create(NumenPlayer player, Supplier<GoalCompiler.Compiled> compiled,
+                         double speed, BooleanSupplier reached,
+                         PlayerNav.ContextProvider contextProvider,
+                         BooleanSupplier sprintAllowed);
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/pathing/exec/PlayerNavSprintGateTestProbe.java
+++ b/common/src/test/java/com/dwinovo/numen/core/pathing/exec/PlayerNavSprintGateTestProbe.java
@@ -1,0 +1,29 @@
+package com.dwinovo.numen.core.pathing.exec;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+import com.dwinovo.numen.core.pathing.settings.NavSettings;
+
+/**
+ * Test-only bridge proving that a gate captured by another package reaches the
+ * exact guard used by {@link PlayerNav}.
+ */
+public final class PlayerNavSprintGateTestProbe {
+
+    private PlayerNavSprintGateTestProbe() {}
+
+    public static boolean observeGuard(BooleanSupplier gate) {
+        NavSettings settings = NavSettings.get();
+        boolean original = settings.allowSprint;
+        AtomicBoolean observed = new AtomicBoolean();
+        try {
+            settings.allowSprint = true;
+            PlayerNav.withSprintGate(gate,
+                    () -> observed.set(settings.allowSprint));
+            return observed.get();
+        } finally {
+            settings.allowSprint = original;
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/pathing/execute/PathExecutorCapabilityGuardTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/pathing/execute/PathExecutorCapabilityGuardTest.java
@@ -1,0 +1,93 @@
+package com.dwinovo.numen.core.pathing.execute;
+
+import com.dwinovo.numen.core.pathing.moves.Input;
+import com.dwinovo.numen.core.pathing.moves.Movement;
+import com.dwinovo.numen.core.pathing.moves.MovementState;
+import com.dwinovo.numen.core.pathing.moves.NavigationCapabilities;
+
+import net.minecraft.core.BlockPos;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PathExecutorCapabilityGuardTest {
+
+    @Test
+    void safeFollowSuppressesBreakPlaceAndBucketInputs() {
+        RecordingDelegate target = new RecordingDelegate();
+        Movement.ExecutionDelegate guarded = PathExecutor.capabilityGuardedDelegate(
+                target, NavigationCapabilities.SAFE_FOLLOW);
+
+        guarded.beginBreaking(null, BlockPos.ZERO);
+        guarded.applyInput(Input.CLICK_LEFT, true);
+        guarded.applyInput(Input.CLICK_RIGHT, true);
+        guarded.applyInput(Input.MOVE_FORWARD, true);
+        guarded.applyRotation(null);
+        guarded.clearInputs();
+
+        assertEquals(0, target.breakRequests);
+        assertEquals(0, target.leftClicks);
+        assertEquals(0, target.rightClicks);
+        assertEquals(1, target.forwardInputs);
+        assertEquals(1, target.rotations);
+        assertEquals(1, target.clears);
+    }
+
+    @Test
+    void defaultPreservesExistingExecutionInputs() {
+        RecordingDelegate target = new RecordingDelegate();
+        Movement.ExecutionDelegate guarded = PathExecutor.capabilityGuardedDelegate(
+                target, NavigationCapabilities.DEFAULT);
+
+        guarded.beginBreaking(null, BlockPos.ZERO);
+        guarded.applyInput(Input.CLICK_LEFT, true);
+        guarded.applyInput(Input.CLICK_RIGHT, true);
+
+        assertEquals(1, target.breakRequests);
+        assertEquals(1, target.leftClicks);
+        assertEquals(1, target.rightClicks);
+    }
+
+    @Test
+    void nullCapabilitiesAreRejectedExplicitly() {
+        assertThrows(NullPointerException.class,
+                () -> PathExecutor.capabilityGuardedDelegate(new RecordingDelegate(), null));
+    }
+
+    private static final class RecordingDelegate implements Movement.ExecutionDelegate {
+        int breakRequests;
+        int rotations;
+        int clears;
+        int leftClicks;
+        int rightClicks;
+        int forwardInputs;
+
+        @Override
+        public void beginBreaking(MovementState state, BlockPos pos) {
+            breakRequests++;
+        }
+
+        @Override
+        public void applyRotation(MovementState.MovementTarget target) {
+            rotations++;
+        }
+
+        @Override
+        public void clearInputs() {
+            clears++;
+        }
+
+        @Override
+        public void applyInput(Input input, boolean held) {
+            if (input == Input.CLICK_LEFT) {
+                leftClicks++;
+            } else if (input == Input.CLICK_RIGHT) {
+                rightClicks++;
+            } else if (input == Input.MOVE_FORWARD) {
+                forwardInputs++;
+            }
+        }
+    }
+}

--- a/common/src/test/java/com/dwinovo/numen/core/pathing/moves/NavigationCapabilitiesTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/pathing/moves/NavigationCapabilitiesTest.java
@@ -1,0 +1,101 @@
+package com.dwinovo.numen.core.pathing.moves;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import it.unimi.dsi.fastutil.longs.LongSet;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.BlockGetter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NavigationCapabilitiesTest {
+
+    @FunctionalInterface
+    private interface LegacySimpleConstructor {
+        CalculationContext create(ServerPlayer player, BlockGetter view,
+                                  ChunkLoadedTest loadedTest, boolean threaded);
+    }
+
+    @FunctionalInterface
+    private interface LegacyProtectedConstructor {
+        CalculationContext create(ServerPlayer player, BlockGetter view,
+                                  ChunkLoadedTest loadedTest, boolean threaded,
+                                  LongSet sacred, LongSet deniedPlace);
+    }
+
+    @FunctionalInterface
+    private interface CapabilityConstructor {
+        CalculationContext create(ServerPlayer player, BlockGetter view,
+                                  ChunkLoadedTest loadedTest, boolean threaded,
+                                  LongSet sacred, LongSet deniedPlace,
+                                  NavigationCapabilities capabilities);
+    }
+
+    @Test
+    void presetsExposeExpectedHardLimits() {
+        assertTrue(NavigationCapabilities.DEFAULT.allowBreak());
+        assertTrue(NavigationCapabilities.DEFAULT.allowPlace());
+        assertTrue(NavigationCapabilities.DEFAULT.allowWaterBucketLanding());
+
+        assertFalse(NavigationCapabilities.SAFE_FOLLOW.allowBreak());
+        assertFalse(NavigationCapabilities.SAFE_FOLLOW.allowPlace());
+        assertFalse(NavigationCapabilities.SAFE_FOLLOW.allowWaterBucketLanding());
+    }
+
+    @Test
+    void safeFollowCannotBeRelaxedByGlobalSettings() {
+        NavigationCapabilities safe = NavigationCapabilities.SAFE_FOLLOW;
+
+        assertFalse(safe.permitsBreak(true));
+        assertFalse(safe.permitsPlace(true));
+        assertFalse(safe.permitsWaterBucketLanding(true));
+        assertEquals(List.of(), safe.permittedBreakExceptions(List.of("global exception")));
+    }
+
+    @Test
+    void defaultPreservesConfiguredBehaviorAndSnapshotsExceptions() {
+        NavigationCapabilities defaults = NavigationCapabilities.DEFAULT;
+        ArrayList<String> configured = new ArrayList<>(List.of("stone"));
+        List<String> snapshot = defaults.permittedBreakExceptions(configured);
+        configured.add("dirt");
+
+        assertTrue(defaults.permitsBreak(true));
+        assertTrue(defaults.permitsPlace(true));
+        assertTrue(defaults.permitsWaterBucketLanding(true));
+        assertFalse(defaults.permitsBreak(false));
+        assertFalse(defaults.permitsPlace(false));
+        assertFalse(defaults.permitsWaterBucketLanding(false));
+        assertEquals(List.of("stone"), snapshot);
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.add("sand"));
+    }
+
+    @Test
+    void immutableValuesDoNotLeakAcrossNavigations() {
+        NavigationCapabilities safe =
+                new NavigationCapabilities(false, false, false);
+        NavigationCapabilities defaults =
+                new NavigationCapabilities(true, true, true);
+
+        assertEquals(NavigationCapabilities.SAFE_FOLLOW, safe);
+        assertEquals(NavigationCapabilities.DEFAULT, defaults);
+        assertNotSame(safe, defaults);
+        assertTrue(defaults.allowBreak());
+        assertFalse(safe.allowBreak());
+    }
+
+    @Test
+    void legacyAndExplicitCalculationContextEntrypointsStillCompile() {
+        LegacySimpleConstructor simple = CalculationContext::new;
+        LegacyProtectedConstructor protectedCells = CalculationContext::new;
+        CapabilityConstructor explicit = CalculationContext::new;
+
+        assertTrue(simple != null && protectedCells != null && explicit != null);
+    }
+}

--- a/fabric/src/main/java/com/dwinovo/numen/core/NumenCoreFabric.java
+++ b/fabric/src/main/java/com/dwinovo/numen/core/NumenCoreFabric.java
@@ -3,6 +3,8 @@ package com.dwinovo.numen.core;
 import com.dwinovo.numen.core.debug.DebugCommands;
 import com.dwinovo.numen.core.debug.PathDebugRenderer;
 import com.dwinovo.numen.core.pathing.cache.PathCaches;
+import com.dwinovo.numen.core.follow.FollowCommands;
+import com.dwinovo.numen.core.follow.FollowConfig;
 import com.dwinovo.numen.core.follow.FollowReleaseReason;
 import com.dwinovo.numen.core.follow.FollowService;
 import com.dwinovo.numen.core.task.ScanBlocksJob;
@@ -39,7 +41,10 @@ public class NumenCoreFabric implements ModInitializer {
         ServerTickEvents.END_SERVER_TICK.register(PathDebugRenderer::serverTick);
         // Debug verbs merged into the /numen root registered by the engine mod.
         CommandRegistrationCallback.EVENT.register(
-                (dispatcher, registryAccess, environment) -> DebugCommands.register(dispatcher));
+                (dispatcher, registryAccess, environment) -> {
+                    DebugCommands.register(dispatcher);
+                    FollowCommands.register(dispatcher, FollowConfig.current());
+                });
 
         Constants.LOG.info("numen-core initialised on Fabric.");
     }

--- a/fabric/src/main/java/com/dwinovo/numen/core/NumenCoreFabric.java
+++ b/fabric/src/main/java/com/dwinovo/numen/core/NumenCoreFabric.java
@@ -3,6 +3,8 @@ package com.dwinovo.numen.core;
 import com.dwinovo.numen.core.debug.DebugCommands;
 import com.dwinovo.numen.core.debug.PathDebugRenderer;
 import com.dwinovo.numen.core.pathing.cache.PathCaches;
+import com.dwinovo.numen.core.follow.FollowReleaseReason;
+import com.dwinovo.numen.core.follow.FollowService;
 import com.dwinovo.numen.core.task.ScanBlocksJob;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -27,6 +29,10 @@ public class NumenCoreFabric implements ModInitializer {
         ServerTickEvents.END_SERVER_TICK.register(ScanBlocksJob::tick);
         // Snapshot loaded chunks near companions for the off-thread planner to read live.
         ServerTickEvents.END_SERVER_TICK.register(PathCaches::serverTick);
+        // Release live follow navigation while companion bodies are still valid.
+        ServerLifecycleEvents.SERVER_STOPPING.register(server ->
+                FollowService.releaseAllRuntime(
+                        server, FollowReleaseReason.SERVER_STOPPING));
         // Release those chunk references when the server stops (don't pin an old world's chunks).
         ServerLifecycleEvents.SERVER_STOPPED.register(server -> PathCaches.dropAll());
         // Debug particles for pathing state, sent only to players with debug on.


### PR DESCRIPTION
## 概述

本 PR 为 Numen 的 Minecraft 1.20.1 分支添加可选的主人自动跟随功能。

关联 Issue：#15

跟随状态按同伴独立保存，玩家可以通过命令或自然语言控制同伴跟随，同时避免跟随行为与对话、战斗、生存等任务争夺移动控制。

## 功能

- 支持 `on`、`off`、`pause`、`resume` 和 `status`
- 支持自然语言 `follow_owner` 工具调用
- 每个同伴独立保存跟随状态
- 使用距离迟滞减少反复走停和移动抖动
- 作为低优先级后台任务接入调度器
- 对话、战斗、生存和紧急任务可以暂时抢占跟随
- 高优先级任务结束后自动重新判断是否恢复跟随
- 同伴死亡或重生后恢复原有跟随状态
- 防止旧身体或旧运行时引用控制新身体
- 支持多个同伴之间的状态隔离

## 命令

```text
/numen follow <companion> status
/numen follow <companion> on
/numen follow <companion> off
/numen follow <companion> pause
/numen follow <companion> resume
```

命令和自然语言工具共用同一套状态控制逻辑。

安全限制

自动跟随不会启用以下能力：

自动破坏或放置方块
水桶落地
传送恢复
跨维度跟随
无限制的原始交互

每个同伴最多只有一个有效跟随导航任务。

验证

原始 1.20.1 实现已完成定向自动化测试和实际游戏运行验证，包括：

开启、关闭、暂停和恢复
正常跟随与靠近后停止
防抖和连续状态切换
对话及调度器抢占后恢复
死亡、重生和状态恢复
多同伴状态隔离
旧运行时引用防护

本 PR 分支已基于官方 1.20.1 分支完成完整构建：

.\gradlew.bat clean build --no-daemon --console=plain

结果：

BUILD SUCCESSFUL in 12m
53 actionable tasks: 53 executed

构建覆盖 common、Fabric 和 Forge 模块。

已知限制

当主人移动到超过可恢复导航范围的位置时，同伴可能停止有效追赶。

该功能有意不使用传送恢复，后续可以继续讨论长距离恢复和主动提示机制。

参考实现

独立测试版本：

https://github.com/hanqingzhou666-wq/numen-auto-follow
https://github.com/hanqingzhou666-wq/numen-auto-follow/releases/tag/v0.1.0