### PR TITLE
fix(fabric 1.20.4): 对easybot模组进行了兼容--假人ip地址修改为127.0.0.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     testImplementation "com.dwinovo.numen:numen-api-common-1.20.4:0.0.8-SNAPSHOT"
 
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
+    testRuntimeOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
     // fabric and forge both bundle mixinextras, so it is safe to use it in common
     compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
     annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'

--- a/common/src/main/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixin.java
+++ b/common/src/main/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixin.java
@@ -1,0 +1,36 @@
+package com.dwinovo.numen.core.mixin;
+
+import com.dwinovo.numen.entity.FakeConnection;
+import net.minecraft.network.Connection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+/** Supply an IP-shaped address for Numen's in-memory fake-player connection. */
+@Mixin(Connection.class)
+public abstract class ConnectionRemoteAddressMixin {
+
+    private static final InetSocketAddress NUMEN_LOOPBACK_ADDRESS =
+            new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+
+    @Inject(method = "getRemoteAddress", at = @At("RETURN"), cancellable = true)
+    private void numen$useCompatibleFakePlayerAddress(CallbackInfoReturnable<SocketAddress> cir) {
+        SocketAddress original = cir.getReturnValue();
+        SocketAddress compatible = numen$compatibleRemoteAddress((Connection) (Object) this, original);
+        if (compatible != original) {
+            cir.setReturnValue(compatible);
+        }
+    }
+
+    private static SocketAddress numen$compatibleRemoteAddress(Connection connection, SocketAddress original) {
+        if (connection instanceof FakeConnection && !(original instanceof InetSocketAddress)) {
+            return NUMEN_LOOPBACK_ADDRESS;
+        }
+        return original;
+    }
+}

--- a/common/src/main/resources/numen.mixins.json
+++ b/common/src/main/resources/numen.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "refmap": "numen.refmap.json",
   "mixins": [
+    "ConnectionRemoteAddressMixin",
     "FishingHookAccessor",
     "ServerLevelBlockChangeMixin"
   ],

--- a/common/src/test/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixinTest.java
+++ b/common/src/test/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixinTest.java
@@ -1,0 +1,81 @@
+package com.dwinovo.numen.core.mixin;
+
+import com.dwinovo.numen.entity.FakeConnection;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.PacketFlow;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectionRemoteAddressMixinTest {
+
+    @Test
+    void convertsEmbeddedFakeConnectionAddressToResolvedLoopback() {
+        FakeConnection connection = new FakeConnection();
+        SocketAddress original = connection.getRemoteAddress();
+        assertFalse(original instanceof InetSocketAddress);
+
+        SocketAddress compatible = invokeCompatibleRemoteAddress(connection, original);
+
+        InetSocketAddress address = assertInstanceOf(InetSocketAddress.class, compatible);
+        assertNotNull(address.getAddress());
+        assertTrue(address.getAddress().isLoopbackAddress());
+        assertEquals(0, address.getPort());
+    }
+
+    @Test
+    void preservesRealConnectionAddress() {
+        Connection connection = new Connection(PacketFlow.SERVERBOUND);
+        InetSocketAddress original = new InetSocketAddress(InetAddress.getLoopbackAddress(), 25565);
+
+        assertSame(original, invokeCompatibleRemoteAddress(connection, original));
+    }
+
+    @Test
+    void preservesAlreadyCompatibleFakeConnectionAddress() {
+        FakeConnection connection = new FakeConnection();
+        InetSocketAddress original = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12345);
+
+        assertSame(original, invokeCompatibleRemoteAddress(connection, original));
+    }
+
+    @Test
+    void keepsStaticCompatibilityHelperPrivateForMixinRuntime() {
+        Method method = compatibleRemoteAddressMethod();
+
+        assertTrue(Modifier.isPrivate(method.getModifiers()),
+                "Mixin 0.8.7 rejects non-private static methods during application");
+    }
+
+    private static SocketAddress invokeCompatibleRemoteAddress(
+            Connection connection, SocketAddress original) {
+        try {
+            return (SocketAddress) compatibleRemoteAddressMethod().invoke(null, connection, original);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new AssertionError("Could not invoke compatibility helper", e);
+        }
+    }
+
+    private static Method compatibleRemoteAddressMethod() {
+        try {
+            Method method = ConnectionRemoteAddressMixin.class.getDeclaredMethod(
+                    "numen$compatibleRemoteAddress", Connection.class, SocketAddress.class);
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("Compatibility helper is missing", e);
+        }
+    }
+}

--- a/docs/plans/2026-08-01-fake-connection-address-compat-design.md
+++ b/docs/plans/2026-08-01-fake-connection-address-compat-design.md
@@ -1,0 +1,70 @@
+# Fake Connection Address Compatibility Design
+
+## Problem
+
+Numen companions are server-side fake players created through the vanilla player join path. Their
+`FakeConnection` owns a Netty `EmbeddedChannel`, whose remote address is an
+`EmbeddedSocketAddress`. Fabric therefore publishes a normal `ServerPlayConnectionEvents.JOIN`
+event for the companion with a non-IP `SocketAddress`.
+
+EasyBot assumes every joined player has an `InetSocketAddress` and casts without checking. When an
+owner logs in and Numen respawns a companion synchronously, EasyBot's exception escapes through the
+owner's join call and Minecraft reports `Invalid player data`.
+
+## Constraints
+
+- The current repository owns Numen Core, not the `FakeConnection` implementation in `numen-api`.
+- The fix must work with the already published `numen-api` 0.0.7 and 0.0.8 artifacts.
+- Real network connections must retain their real remote address.
+- A future `numen-api` release that supplies an `InetSocketAddress` must not be overwritten.
+- The vanilla player join path and Fabric join events must remain intact.
+- Every static method declared by a Mixin class must be private so Mixin 0.8.7 can apply it.
+
+## Design
+
+Add a common Mixin on `net.minecraft.network.Connection#getRemoteAddress`. At method return, inspect
+the receiver and the original address:
+
+- For a `com.dwinovo.numen.entity.FakeConnection` whose address is not an
+  `InetSocketAddress`, return a resolved loopback address on port `0`.
+- For real connections, return the original object unchanged.
+- For a future already-compatible fake connection, return its original `InetSocketAddress`
+  unchanged.
+
+The compatibility policy lives in a private static method on the Mixin class. This satisfies Mixin's
+runtime visibility rules while keeping the hook small. Ordinary JUnit tests invoke that private method
+reflectively so the policy remains directly covered without bootstrapping a Minecraft Mixin runtime.
+The test runtime includes the same Mixin API already used at compile time because Java reflection must
+resolve the injection handler's `CallbackInfoReturnable` parameter while enumerating declared methods;
+this dependency remains test-only and is not bundled into either loader artifact.
+
+## Data Flow
+
+1. Numen creates a `FakeConnection` backed by an `EmbeddedChannel`.
+2. A mod calls the standard `Connection#getRemoteAddress` API during the fake player's join event.
+3. The Mixin receives the original embedded address.
+4. The compatibility policy substitutes `127.0.0.1:0` (or the JVM's resolved loopback equivalent).
+5. EasyBot receives an `InetSocketAddress`; real player addresses are untouched.
+
+## Error Handling
+
+The hook does not catch third-party exceptions and does not alter event ordering. It only normalizes
+the fake connection's address contract. Port `0` communicates that there is no real remote socket,
+while a resolved loopback address avoids null-address failures in code that calls
+`InetSocketAddress#getAddress`.
+
+## Testing
+
+Unit tests cover three cases:
+
+1. The current `FakeConnection` embedded address becomes a resolved loopback
+   `InetSocketAddress` on port `0`.
+2. A normal `Connection` keeps the exact original address object.
+3. An already-compatible fake connection address is preserved, protecting future API fixes.
+
+A structural regression test also requires the compatibility helper to remain private. This mirrors
+Mixin 0.8.7's applicator check and prevents a build-only verification run from producing another JAR
+that compiles and remaps successfully but fails when the server transforms `Connection`.
+
+The full Gradle test and build tasks then verify compilation, Mixin remapping, resources, and both
+loader artifacts.

--- a/docs/plans/2026-08-01-fake-connection-address-compat.md
+++ b/docs/plans/2026-08-01-fake-connection-address-compat.md
@@ -1,0 +1,134 @@
+# Fake Connection Address Compatibility Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent EasyBot from crashing owner login when a Numen fake player exposes Netty's non-IP embedded remote address.
+
+**Architecture:** Inject at the return of Minecraft's `Connection#getRemoteAddress` and normalize only Numen `FakeConnection` values that are not already `InetSocketAddress` instances. Keep the normalization policy as a private static Mixin helper, invoke it reflectively from policy tests, and assert its visibility so Mixin 0.8.7 can apply the class at runtime.
+
+**Tech Stack:** Java 17, Sponge Mixin 0.8.5 compile API / 0.8.7 runtime, Minecraft 1.20.4 official mappings, JUnit 5, Gradle multi-loader build.
+
+---
+
+### Task 1: Add the failing compatibility tests
+
+**Files:**
+- Create: `common/src/test/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixinTest.java`
+
+**Step 1: Write the failing test**
+
+Create tests that instantiate the published `FakeConnection`, pass its current embedded address to
+`ConnectionRemoteAddressMixin.numen$compatibleRemoteAddress`, and require a resolved loopback
+`InetSocketAddress` on port `0`. Add preservation tests for a normal `Connection` and an
+already-compatible fake address.
+
+**Step 2: Run the focused test to verify it fails**
+
+Run: `.\\gradlew.bat :common:test --tests com.dwinovo.numen.core.mixin.ConnectionRemoteAddressMixinTest --offline`
+
+Expected: FAIL during test compilation because `ConnectionRemoteAddressMixin` does not exist yet.
+
+### Task 2: Implement the minimal Mixin
+
+**Files:**
+- Create: `common/src/main/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixin.java`
+- Modify: `common/src/main/resources/numen.mixins.json`
+
+**Step 1: Add the compatibility policy**
+
+Implement a static resolved loopback `InetSocketAddress` and a package-visible method that returns it
+only when the connection is `FakeConnection` and the original address is not already an
+`InetSocketAddress`.
+
+**Step 2: Add the runtime hook**
+
+Inject at `Connection#getRemoteAddress` return with a cancellable
+`CallbackInfoReturnable<SocketAddress>`. Replace the return value only when the compatibility method
+returns a different object.
+
+**Step 3: Register the Mixin**
+
+Add `ConnectionRemoteAddressMixin` to `numen.mixins.json`.
+
+**Step 4: Run the focused test to verify it passes**
+
+Run: `.\\gradlew.bat :common:test --tests com.dwinovo.numen.core.mixin.ConnectionRemoteAddressMixinTest --offline`
+
+Expected: PASS.
+
+### Task 3: Verify the repository
+
+**Files:**
+- Verify: all changed files
+
+**Step 1: Run all unit tests**
+
+Run: `.\\gradlew.bat test --offline`
+
+Expected: all tests pass.
+
+**Step 2: Build all loader artifacts**
+
+Run: `.\\gradlew.bat build --offline`
+
+Expected: BUILD SUCCESSFUL, including Fabric remapping and Forge assembly.
+
+**Step 3: Check the patch**
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+**Step 4: Review changed files**
+
+Run: `git diff -- common/src/main/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixin.java common/src/main/resources/numen.mixins.json common/src/test/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixinTest.java`
+
+Expected: only the scoped compatibility hook, registration, and regression tests.
+
+### Task 4: Enforce Mixin Runtime Visibility
+
+**Files:**
+- Modify: `common/build.gradle`
+- Modify: `common/src/test/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixinTest.java`
+- Modify: `common/src/main/java/com/dwinovo/numen/core/mixin/ConnectionRemoteAddressMixin.java`
+
+**Step 1: Add Mixin to the test runtime**
+
+Add `testRuntimeOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'`. Reflection resolves
+the injection handler's `CallbackInfoReturnable` type, while the production artifacts continue to use
+the loader-provided runtime.
+
+**Step 2: Make existing policy tests compatible with a private helper**
+
+Add a test-only reflective invocation helper using `getDeclaredMethod`, `setAccessible(true)`, and
+`Method#invoke`. Route the three existing policy tests through it. Production code remains unchanged.
+
+**Step 3: Write the failing visibility regression test**
+
+Resolve `numen$compatibleRemoteAddress(Connection, SocketAddress)` and assert that
+`Modifier.isPrivate(method.getModifiers())` is true.
+
+**Step 4: Run the focused test to verify it fails for the reported reason**
+
+Run: `.\\gradlew.bat :common:test --tests com.dwinovo.numen.core.mixin.ConnectionRemoteAddressMixinTest`
+
+Expected: FAIL only in the visibility regression test because the helper is package-visible.
+
+**Step 5: Implement the minimal production fix**
+
+Change the helper declaration from `static SocketAddress` to `private static SocketAddress`. Do not
+alter address selection or injection behavior.
+
+**Step 6: Run the focused test to verify it passes**
+
+Run: `.\\gradlew.bat :common:test --tests com.dwinovo.numen.core.mixin.ConnectionRemoteAddressMixinTest`
+
+Expected: all four tests PASS.
+
+**Step 7: Verify runtime packaging and the full repository**
+
+Run the Fabric server far enough to apply `numen.mixins.json`, then run `.\\gradlew.bat build`, inspect
+the remapped Fabric JAR with `javap -p`, and run `git diff --check`.
+
+Expected: no `InvalidMixinException`, a private compiled helper, a successful multi-loader build, and
+no whitespace errors.


### PR DESCRIPTION
我在服务器环境中安装了该模组和easybot模组出现了错误，发现假人不能进入服务器，退出后在单人模式配置完后再次进入服务器显示无效的玩家数据，经过替换之前正常的玩家数据无用且不能在服务器内通过carpet将玩家以假人形式加入服务器，经过检查，发现原因如下 Numen 用 EmbeddedChannel 创建假玩家，并触发 Fabric 的玩家 JOIN 事件。EasyBot 将通用 SocketAddress 强转成 InetSocketAddress，未考虑假玩家连接于是连带进入玩家崩溃。Invalid player data 只是登录流程被异常中断后的结果，不代表玩家存档损坏。当前依赖的 Numen API 0.0.8 仍有同样实现，单纯升级不能解决。 解决方案：让 FakeConnection#getRemoteAddress() 返回 127.0.0.1:0 的 InetSocketAddress。改动很小，并保留现有假玩家登录流程。经测试，修改后的模组功能正常，假人可以正常调用ai。