### PR TITLE
feat(build): 创造模式建筑贴地基座 + 连接型方块连接修复

### DIFF
--- a/common/src/main/java/com/dwinovo/numen/core/task/BuildCompanionTask.java
+++ b/common/src/main/java/com/dwinovo/numen/core/task/BuildCompanionTask.java
@@ -1298,6 +1298,7 @@ public final class BuildCompanionTask extends AbstractCompanionTask<BuildTaskRec
         scaffold.clear();
         spawnFixtures();
         nudgeSurroundingWater();
+        refreshConnectedBlocks();
         if (player.level() instanceof ServerLevel level) {
             level.sendParticles(ParticleTypes.HAPPY_VILLAGER,
                     (siteMin.getX() + siteMax.getX()) / 2.0 + 0.5,
@@ -1332,6 +1333,36 @@ public final class BuildCompanionTask extends AbstractCompanionTask<BuildTaskRec
             note = notes.isEmpty() ? "all requested cells match" : String.join("; ", notes);
         }
         return TaskState.SUCCESS;
+    }
+
+    /**
+     * 收尾时，对连接型方块（栅栏、玻璃板、铁栏杆等带 NORTH/EAST/SOUTH/WEST 属性的）
+     * 补一次邻居更新，让它们根据最终邻居重新算连接状态。
+     *
+     * <p>落位时刻意不带 {@code UPDATE_NEIGHBORS}（见 {@code PLACE_FLAGS}），那是为了
+     * 不让原版中途改写图纸。但连接型方块的状态天生依赖邻居，不更新就是一排孤立的
+     * 栅栏柱。收尾时所有格子都已落位，此时触发一次更新，连接状态正好一次算准。
+     */
+    private void refreshConnectedBlocks() {
+        net.minecraft.server.level.ServerLevel level =
+                (net.minecraft.server.level.ServerLevel) player.level();
+        for (BuildTaskRecord.Target target : r.targets) {
+            if (!target.desiredState().hasProperty(BlockStateProperties.NORTH)) {
+                continue;
+            }
+            BlockPos pos = target.pos();
+            BlockState state = level.getBlockState(pos);
+            if (state.isAir()) {
+                continue;
+            }
+            // 按 6 个方向算连接状态：updateShape 只更新当前方向对应的属性，
+            for (Direction dir : Direction.values()) {
+                BlockPos neighborPos = pos.relative(dir);
+                BlockState neighborState = level.getBlockState(neighborPos);
+                state = state.updateShape(dir, neighborState, level, pos, neighborPos);
+            }
+            level.setBlock(pos, state, PLACE_FLAGS);
+        }
     }
 
     // ------------------------------------------------------------------

--- a/common/src/main/java/com/dwinovo/numen/core/tools/BuildTool.java
+++ b/common/src/main/java/com/dwinovo/numen/core/tools/BuildTool.java
@@ -283,10 +283,88 @@ public final class BuildTool implements NumenTool {
         // 材料记账随能力画像:免耗材(创造)想建就建;否则消耗背包,开工前
         // 由任务预检并逐项报缺(见 BuildCompanionTask 的 checkMaterials)。
         boolean consume = !com.dwinovo.numen.core.task.WorkProfile.of(companion).freeMaterials();
+        if (!consume) {
+            // 创造（免耗材）：贴到地面众数高度，并在下方填 3 格泥土基座。泥土基座不扣料。
+            targets = adaptToGround(companion, targets);
+        }
         long timeout = timeoutTicksFor(targets.size(), consume);
         dispatchAsync(companion, new BuildTaskRecord(toolCallId,
                 ctx(toolCallId, companion).deadline(timeout), targets, replaceExisting,
                 consume), reply);
+    }
+
+    /**
+     * 创造模式的地面适配：把整栋建筑垂直贴到这块空地「地面高度的众数」，并在下方
+     * 填 3 格泥土基座——这样既不会悬空，也不会陷进个别坑里。
+     *
+     * <p>只对免耗材（创造）调用：生存模式填基座要扣泥土、盘料逻辑复杂，先不碰。
+     */
+    private static List<BuildTaskRecord.Target> adaptToGround(
+            NumenPlayer companion, List<BuildTaskRecord.Target> targets) {
+        net.minecraft.server.level.ServerLevel level =
+                (net.minecraft.server.level.ServerLevel) companion.level();
+
+        // 1) footprint 范围 + 蓝图最低实心 Y
+        int minX = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE;
+        int minZ = Integer.MAX_VALUE, maxZ = Integer.MIN_VALUE;
+        int minY = Integer.MAX_VALUE;
+        for (BuildTaskRecord.Target t : targets) {
+            BlockPos p = t.pos();
+            minX = Math.min(minX, p.getX());
+            maxX = Math.max(maxX, p.getX());
+            minZ = Math.min(minZ, p.getZ());
+            maxZ = Math.max(maxZ, p.getZ());
+            if (!t.desiredState().isAir()) {
+                minY = Math.min(minY, p.getY());
+            }
+        }
+        if (minY == Integer.MAX_VALUE) {
+            return targets;   // 全是空气格，没有可贴地的实心内容
+        }
+
+        // 2) 每列 (x,z) 从蓝图最低 Y 往下找第一个非空气，作为该列地面高度
+        Map<Integer, Integer> groundCounts = new LinkedHashMap<>();
+        for (int x = minX; x <= maxX; x++) {
+            for (int z = minZ; z <= maxZ; z++) {
+                int gy = minY;
+                while (gy > level.getMinBuildHeight()
+                        && level.getBlockState(new BlockPos(x, gy, z)).isAir()) {
+                    gy--;
+                }
+                groundCounts.merge(gy, 1, Integer::sum);
+            }
+        }
+
+        // 3) 众数地面 Y（出现最多的那个高度）
+        int modeY = minY;
+        int modeCount = -1;
+        for (Map.Entry<Integer, Integer> e : groundCounts.entrySet()) {
+            if (e.getValue() > modeCount) {
+                modeY = e.getKey();
+                modeCount = e.getValue();
+            }
+        }
+        int dy = modeY - minY;
+
+        // 4) 整体垂直偏移 + 生成泥土基座
+        List<BuildTaskRecord.Target> out = new ArrayList<>(targets.size() + 64);
+        for (BuildTaskRecord.Target t : targets) {
+            BlockPos p = t.pos().offset(0, dy, 0);
+            out.add(new BuildTaskRecord.Target(t.desiredState(), t.item(), p, t.label(),
+                    t.facing(), t.axis(), t.topHalf()));
+        }
+        for (int x = minX; x <= maxX; x++) {
+            for (int z = minZ; z <= maxZ; z++) {
+                for (int y = modeY - 1; y >= modeY - 3; y--) {
+                    BlockPos p = new BlockPos(x, y, z);
+                    if (level.getBlockState(p).isAir()) {
+                        out.add(new BuildTaskRecord.Target(Blocks.DIRT, Items.DIRT, p,
+                                "基座", null, null, null));
+                    }
+                }
+            }
+        }
+        return out;
     }
 
     /** 一条指令展开为目标格集。set/set_door 携带状态;体积算子单一方块类型。 */


### PR DESCRIPTION
问题 1：build 没有选定基面，一旦不是超平坦平地就一定悬空。
解决 1：蓝图最低 y 坐标选这一块空地的众数 y 坐标；蓝图往下 3 格，遇空气则填泥土（基座）。因为生存模式会产生额外耗材，只做了创造模式的修改。

问题 2：栅栏、玻璃板、铁栏杆等连接型方块放置后连接状态不对——落位时跳过 getStateForPlacement 又不带邻居更新，导致一排孤立的栅栏柱、玻璃板不贴墙。
解决 2：建造收尾时按 6 个方向 updateShape 重算连接状态并写回，让它们贴合最终邻居。